### PR TITLE
Add expandable media shelves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Prismarr are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Expandable shelves in the Radarr and Sonarr shelf views, allowing shelves to wrap into multi-row grids while keeping the collapsed behavior.
+
 ## [1.0.6] - 2026-05-03
 
 ### Added

--- a/symfony/templates/media/films.html.twig
+++ b/symfony/templates/media/films.html.twig
@@ -159,8 +159,14 @@
 /* Shelves view (movies) */
 #films-shelf-view { display: none; }
 .shelf-section { margin-bottom: 1.5rem; }
-.shelf-section h4 { font-size: .85rem; margin-bottom: .5rem; padding-left: .2rem; }
+.shelf-header { display: flex; align-items: center; gap: .35rem; margin-bottom: .5rem; padding-left: .2rem; }
+.shelf-section h4 { font-size: .85rem; margin: 0; }
+.shelf-toggle { border: 0; background: transparent; color: var(--tblr-muted); padding: .1rem .25rem; line-height: 1; border-radius: .25rem; transition: color .15s, background-color .15s, transform .15s; }
+.shelf-toggle:hover { color: var(--tblr-body-color); background: var(--tblr-bg-surface-secondary); }
+.shelf-toggle .shelf-chevron { display: inline-block; transition: transform .15s; }
+.shelf-section.is-expanded .shelf-toggle .shelf-chevron { transform: rotate(90deg); }
 .shelf-scroll { display: flex; gap: .5rem; overflow-x: auto; padding-bottom: .5rem; scrollbar-width: thin; }
+.shelf-section.is-expanded .shelf-scroll { flex-wrap: wrap; overflow-x: visible; }
 .shelf-scroll .shelf-card { flex-shrink: 0; width: 110px; cursor: pointer; position: relative; border-radius: .4rem; overflow: hidden; transition: transform .15s; }
 .shelf-scroll .shelf-card:hover { transform: scale(1.05); z-index: 2; }
 .shelf-scroll .shelf-card img { width: 100%; aspect-ratio: 2/3; object-fit: cover; display: block; }
@@ -4038,6 +4044,7 @@
   var filmsTableView = document.getElementById('films-table-view');
   var filmsShelfView = document.getElementById('films-shelf-view');
   var filmsShelfBuilt = false;
+  var filmsShelfExpanded = {};
 
   function buildFilmsShelf() {
     if (filmsShelfBuilt) return;
@@ -4079,7 +4086,10 @@
     ['downloaded','missing','unmonitored'].forEach(function(key) {
       var g = groups[key];
       if (!g.items.length) return;
-      html += '<div class="shelf-section"><h4>' + g.label + ' <span class="text-muted fw-normal" style="font-size:.75rem;">(' + g.items.length + ')</span></h4>';
+      var isExpanded = !!filmsShelfExpanded[key];
+      html += '<div class="shelf-section' + (isExpanded ? ' is-expanded' : '') + '" data-shelf="' + key + '">';
+      html += '<div class="shelf-header"><button type="button" class="shelf-toggle" data-shelf-toggle="' + key + '" aria-label="Toggle shelf" aria-expanded="' + (isExpanded ? 'true' : 'false') + '"><span class="shelf-chevron">›</span></button>';
+      html += '<h4>' + g.label + ' <span class="text-muted fw-normal" style="font-size:.75rem;">(' + g.items.length + ')</span></h4></div>';
       html += '<div class="shelf-scroll">';
       g.items.forEach(function(item) {
         var barColor = item.hasFile ? '#22c55e' : (item.monitored ? '#f59e0b' : '#6b7280');
@@ -4092,7 +4102,15 @@
       html += '</div></div>';
     });
     filmsShelfView.innerHTML = html;
-    filmsShelfView.addEventListener('click', function(e) {
+    filmsShelfView.onclick = function(e) {
+      var toggle = e.target.closest('[data-shelf-toggle]');
+      if (toggle) {
+        var shelfKey = toggle.dataset.shelfToggle;
+        filmsShelfExpanded[shelfKey] = !filmsShelfExpanded[shelfKey];
+        filmsShelfBuilt = false;
+        buildFilmsShelf();
+        return;
+      }
       var sc = e.target.closest('.shelf-card');
       if (!sc) return;
       var id = sc.dataset.id;
@@ -4105,7 +4123,7 @@
       }
       var card = grid.querySelector('.media-card[data-id="' + id + '"]');
       if (card) card.click();
-    });
+    };
   }
 
   function setFilmsViewMode(mode) {

--- a/symfony/templates/media/series.html.twig
+++ b/symfony/templates/media/series.html.twig
@@ -184,11 +184,17 @@
 .media-grid.view-wall .media-card:hover { transform: none; box-shadow: none; z-index: 2; }
 /* Vue étagères */
 .shelf-section { margin-bottom: 1.5rem; }
-.shelf-section h4 { font-size: .85rem; margin-bottom: .5rem; padding-left: .2rem; }
+.shelf-header { display: flex; align-items: center; gap: .35rem; margin-bottom: .5rem; padding-left: .2rem; }
+.shelf-section h4 { font-size: .85rem; margin: 0; }
+.shelf-toggle { border: 0; background: transparent; color: var(--tblr-muted); padding: .1rem .25rem; line-height: 1; border-radius: .25rem; transition: color .15s, background-color .15s, transform .15s; }
+.shelf-toggle:hover { color: var(--tblr-body-color); background: var(--tblr-bg-surface-secondary); }
+.shelf-toggle .shelf-chevron { display: inline-block; transition: transform .15s; }
+.shelf-section.is-expanded .shelf-toggle .shelf-chevron { transform: rotate(90deg); }
 .shelf-scroll {
     display: flex; gap: .5rem; overflow-x: auto; padding-bottom: .5rem;
     scrollbar-width: thin;
 }
+.shelf-section.is-expanded .shelf-scroll { flex-wrap: wrap; overflow-x: visible; }
 .shelf-scroll .shelf-card {
     flex-shrink: 0; width: 110px; cursor: pointer; position: relative;
     border-radius: .4rem; overflow: hidden; transition: transform .15s;
@@ -1354,6 +1360,7 @@
   var tableView = document.getElementById('series-table-view');
   var shelfView = document.getElementById('series-shelf-view');
   var shelfBuilt = false;
+  var shelfExpanded = {};
 
   function buildShelfView() {
     if (shelfBuilt) return;
@@ -1399,7 +1406,10 @@
     ['continuing','anime','ended','upcoming','unmonitored'].forEach(function(key) {
       var g = groups[key];
       if (!g.items.length) return;
-      html += '<div class="shelf-section"><h4>' + g.label + ' <span class="text-muted fw-normal" style="font-size:.75rem;">(' + g.items.length + ')</span></h4>';
+      var isExpanded = !!shelfExpanded[key];
+      html += '<div class="shelf-section' + (isExpanded ? ' is-expanded' : '') + '" data-shelf="' + key + '">';
+      html += '<div class="shelf-header"><button type="button" class="shelf-toggle" data-shelf-toggle="' + key + '" aria-label="Toggle shelf" aria-expanded="' + (isExpanded ? 'true' : 'false') + '"><span class="shelf-chevron">›</span></button>';
+      html += '<h4>' + g.label + ' <span class="text-muted fw-normal" style="font-size:.75rem;">(' + g.items.length + ')</span></h4></div>';
       html += '<div class="shelf-scroll">';
       g.items.forEach(function(item) {
         var barColor = item.percent === 100 ? '#22c55e' : (item.percent > 0 ? '#ef4444' : '#6b7280');
@@ -1414,7 +1424,15 @@
     });
     shelfView.innerHTML = html;
     // Click handler
-    shelfView.addEventListener('click', function(e) {
+    shelfView.onclick = function(e) {
+      var toggle = e.target.closest('[data-shelf-toggle]');
+      if (toggle) {
+        var shelfKey = toggle.dataset.shelfToggle;
+        shelfExpanded[shelfKey] = !shelfExpanded[shelfKey];
+        shelfBuilt = false;
+        buildShelfView();
+        return;
+      }
       var sc = e.target.closest('.shelf-card');
       if (!sc) return;
       var id = sc.dataset.id;
@@ -1426,7 +1444,7 @@
       }
       var card = grid.querySelector('.media-card[data-id="' + id + '"]');
       if (card) card.click();
-    });
+    };
   }
 
   function setViewMode(mode) {


### PR DESCRIPTION
## What does this PR do?

Adds expandable shelves to the Radarr and Sonarr shelf views. Collapsed shelves keep the existing horizontal scrolling behavior while expanded shelves wrap items into multiple rows so larger groups can be easily browsed.

## Type of change

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change (requires a migration plan - see CONTRIBUTING.md golden rule #3)
- [ ] Documentation only

## Definition of Done checklist

- [X] The feature works end-to-end, tested manually in a running container
- [X] No `console.log`, `dd()`, `var_dump`, `TODO`, `FIXME` leftover
- [X] Comments are in English
- [X] **Zero credentials** in code, commits, logs, or docs
- [ ] At least one unit test for new business logic - N/A
- [ ] If this is a bug fix: a regression test that reproduces the bug is included - N/A
- [X] `make check` passes locally
- [ ] If an entity was modified: a new migration is committed - N/A
- [X] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `README.md` updated if user-facing behaviour changed - N/A

## Notes for the reviewer

Verified:
- Radarr shelves collapse/expand correctly
- Sonarr shelves collapse/expand correctly
- Poster clicks still open details
- Filters/search continue to rebuild shelves correctly
- Other view modes are unaffected
