### PR TITLE
Use X-API-Key in Gluetun client and remove non-existing WireGuard endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Prismarr are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Gluetun integration with API key set, and incorrect endpoints.** The Gluetun client authenticated using `Authorization: Bearer <key>`, but Gluetun expects it as `X-API-Key`, so it would return a 401 error when an API key is required. Additionally, referring to the older [Control Server Docs](https://github.com/qdm12/gluetun-wiki/blob/7025b1c0e4427d4477e47d4bbd2ef3f1b5c4da71/setup/advanced/control-server.md#openvpn-and-wireguard), WireGuard doesn't get its own endpoint, so the `/v1/wireguard/status` and `/v1/wireguard/portforwarded` calls were incorrect. The client now sends `X-API-Key` and uses the unified `/v1/vpn/status` and `/v1/portforward` endpoints, with the legacy `/v1/openvpn/` paths as a fallback. With that, the protocol selector in the settings becomes redundant and was removed.
+
 ## [1.1.1] - 2026-06-10
 
 ### Fixed

--- a/symfony/src/Controller/AdminSettingsController.php
+++ b/symfony/src/Controller/AdminSettingsController.php
@@ -81,7 +81,6 @@ class AdminSettingsController extends AbstractController
         'gluetun' => [
             ['key' => 'gluetun_url',      'type' => 'text',     'label' => 'admin.field.url'],
             ['key' => 'gluetun_api_key',  'type' => 'password', 'label' => 'admin.field.api_key_if_protected'],
-            ['key' => 'gluetun_protocol', 'type' => 'text',     'label' => 'admin.field.protocol'],
         ],
     ];
 

--- a/symfony/src/Controller/SetupController.php
+++ b/symfony/src/Controller/SetupController.php
@@ -313,7 +313,6 @@ class SetupController extends AbstractController
             'qbittorrent_password' => '',
             'gluetun_url' => '',
             'gluetun_api_key' => '',
-            'gluetun_protocol' => '',
             // Usenet download clients (optional, like qBittorrent above).
             'sabnzbd_url' => '',
             'sabnzbd_api_key' => '',

--- a/symfony/src/Service/Media/GluetunClient.php
+++ b/symfony/src/Service/Media/GluetunClient.php
@@ -31,7 +31,6 @@ class GluetunClient implements ResetInterface
 
     private ?string $baseUrl = null;
     private string $apiKey = '';
-    private string $protocol = '';
     private bool $configLoaded = false;
 
     public function __construct(
@@ -44,7 +43,6 @@ class GluetunClient implements ResetInterface
         if ($this->configLoaded) return;
         $this->baseUrl  = $this->config->get('gluetun_url');
         $this->apiKey   = $this->config->get('gluetun_api_key') ?? '';
-        $this->protocol = $this->config->get('gluetun_protocol') ?? '';
         $this->configLoaded = true;
     }
 
@@ -53,7 +51,6 @@ class GluetunClient implements ResetInterface
         $this->configLoaded    = false;
         $this->baseUrl         = null;
         $this->apiKey          = '';
-        $this->protocol        = '';
         $this->publicIpCache   = null;
         $this->publicIpCacheAt = 0.0;
         $this->statusCache     = null;
@@ -83,8 +80,9 @@ class GluetunClient implements ResetInterface
 
     /**
      * VPN status — 'running', 'stopped', 'crashed'.
-     * Uses /v1/vpn/status (protocol-agnostic, Gluetun v3.40+) then falls back to protocol-specific.
-     * 10s cache (avoids up to 3 sequential cURL requests on every /api/vpn).
+     * Uses the unified /v1/vpn/status (protocol-agnostic, Gluetun v3.40+), then
+     * falls back to the legacy /v1/openvpn/status for pre-v3.40 OpenVPN installs.
+     * 10s cache (avoids sequential cURL requests on every /api/vpn).
      */
     public function getVpnStatus(): ?string
     {
@@ -93,13 +91,7 @@ class GluetunClient implements ResetInterface
             return $this->statusCache;
         }
 
-        $this->ensureConfig();
-        $fallback = match (strtolower($this->protocol)) {
-            'openvpn'   => ['/v1/openvpn/status'],
-            'wireguard' => ['/v1/wireguard/status'],
-            default     => ['/v1/openvpn/status', '/v1/wireguard/status'],
-        };
-        foreach (array_merge(['/v1/vpn/status'], $fallback) as $path) {
+        foreach ($this->statusPaths() as $path) {
             $data = $this->get($path);
             if ($data !== null && isset($data['status'])) {
                 $this->statusCache   = (string)$data['status'];
@@ -110,10 +102,15 @@ class GluetunClient implements ResetInterface
         return $this->statusCache;
     }
 
+    private function statusPaths(): array
+    {
+        return ['/v1/vpn/status', '/v1/openvpn/status'];
+    }
+
     /**
      * Port forwarded by the VPN provider (the one Gluetun should push to qBit via port-update).
-     * Gluetun v3.40+ exposes /v1/portforward (protected by default — HTTP_CONTROL_SERVER_AUTH_CONFIG_FILEPATH config required).
-     * Falls back to the legacy /v1/openvpn/portforwarded and /v1/wireguard/portforwarded per GLUETUN_PROTOCOL.
+     * Gluetun v3.40+ exposes the unified /v1/portforward (protected by default — HTTP_CONTROL_SERVER_AUTH_CONFIG_FILEPATH config required).
+     * Falls back to the legacy /v1/openvpn/portforwarded endpoint.
      * 10s cache.
      */
     public function getForwardedPort(): ?int
@@ -123,13 +120,7 @@ class GluetunClient implements ResetInterface
             return $this->portCache;
         }
 
-        $this->ensureConfig();
-        $legacy = match (strtolower($this->protocol)) {
-            'openvpn'   => ['/v1/openvpn/portforwarded'],
-            'wireguard' => ['/v1/wireguard/portforwarded'],
-            default     => ['/v1/openvpn/portforwarded', '/v1/wireguard/portforwarded'],
-        };
-        foreach (array_merge(['/v1/portforward'], $legacy) as $path) {
+        foreach ($this->portPaths() as $path) {
             $data = $this->get($path);
             if ($data !== null && isset($data['port'])) {
                 $this->portCache   = (int)$data['port'];
@@ -138,6 +129,11 @@ class GluetunClient implements ResetInterface
             }
         }
         return $this->portCache;
+    }
+
+    private function portPaths(): array
+    {
+        return ['/v1/portforward', '/v1/openvpn/portforwarded'];
     }
 
     /**
@@ -177,8 +173,9 @@ class GluetunClient implements ResetInterface
             CURLOPT_PROTOCOLS       => CURLPROTO_HTTP | CURLPROTO_HTTPS,
             CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
         ];
-        if ($this->apiKey !== '') {
-            $opts[CURLOPT_HTTPHEADER] = ['Authorization: Bearer ' . $this->apiKey];
+        $headers = $this->authHeaders();
+        if ($headers !== []) {
+            $opts[CURLOPT_HTTPHEADER] = $headers;
         }
         $ch = curl_init($url);
         curl_setopt_array($ch, $opts);
@@ -191,5 +188,14 @@ class GluetunClient implements ResetInterface
             return null;
         }
         return json_decode($body, true) ?: null;
+    }
+
+    /**
+     * cURL header list carrying the Gluetun API key, or [] when no key is set.
+     */
+    private function authHeaders(): array
+    {
+        $this->ensureConfig();
+        return $this->apiKey !== '' ? ['X-API-Key: ' . $this->apiKey] : [];
     }
 }

--- a/symfony/templates/setup/downloads.html.twig
+++ b/symfony/templates/setup/downloads.html.twig
@@ -130,19 +130,10 @@
       <div class="wizard-section-title">{{ ico.icon('shield', '', 18) }} {{ 'setup.step.downloads.gluetun.section'|trans }} <span class="text-muted" style="font-weight:400;font-size:.75rem;">{{ 'setup.step.downloads.gluetun.section_suffix'|trans }}</span></div>
       <div class="wizard-section-subtitle">{{ 'setup.step.downloads.gluetun.subtitle'|trans }}</div>
       <div class="row g-3">
-        <div class="col-md-7">
+        <div class="col-md-12">
           <label class="form-label" for="gluetun_url">{{ 'setup.step.downloads.gluetun.url'|trans }}</label>
           <input type="text" id="gluetun_url" name="gluetun_url" class="form-control"
                  placeholder="http://host.docker.internal:8000" value="{{ values.gluetun_url }}"/>
-        </div>
-        <div class="col-md-5">
-          <label class="form-label" for="gluetun_protocol">{{ 'setup.step.downloads.gluetun.protocol'|trans }}</label>
-          <select id="gluetun_protocol" name="gluetun_protocol" class="form-select">
-            {% set p = values.gluetun_protocol %}
-            <option value=""          {{ p == ''          ? 'selected' }}>{{ 'setup.step.downloads.gluetun.protocol_auto'|trans }}</option>
-            <option value="openvpn"   {{ p == 'openvpn'   ? 'selected' }}>OpenVPN</option>
-            <option value="wireguard" {{ p == 'wireguard' ? 'selected' }}>WireGuard</option>
-          </select>
         </div>
         <div class="col-md-12">
           <label class="form-label" for="gluetun_api_key">{{ 'setup.step.downloads.gluetun.api_key'|trans }} <span class="text-muted">{{ 'setup.step.downloads.gluetun.api_key_optional'|trans }}</span></label>

--- a/symfony/tests/Service/Media/GluetunClientTest.php
+++ b/symfony/tests/Service/Media/GluetunClientTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Tests\Service\Media;
+
+use App\Service\ConfigService;
+use App\Service\Media\GluetunClient;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Regression suite for the Gluetun control-server integration:
+ *
+ *  1. The client used to authenticate with `Authorization: Bearer <key>`, but
+ *     Gluetun reads the key from the `X-API-Key` header, so any configured key
+ *     would not work and the integration only worked if the authentication was
+ *     set to "none".
+ *  2. The endpoint fallbacks `/v1/wireguard/status` and
+ *     `/v1/wireguard/portforwarded` don't exist.
+ */
+#[AllowMockObjectsWithoutExpectations]
+class GluetunClientTest extends TestCase
+{
+    private function makeClient(?string $apiKey): GluetunClient
+    {
+        $config = $this->createMock(ConfigService::class);
+        $config->method('get')->willReturnMap([
+            ['gluetun_url', 'http://gluetun:8000'],
+            ['gluetun_api_key', $apiKey],
+        ]);
+
+        return new GluetunClient($config, $this->createMock(LoggerInterface::class));
+    }
+
+    private function invokePrivate(GluetunClient $client, string $method): mixed
+    {
+        return (new \ReflectionMethod($client, $method))->invoke($client);
+    }
+
+    public function testAuthHeaderUsesXApiKeyNotBearer(): void
+    {
+        $headers = $this->invokePrivate($this->makeClient('s3cret-key'), 'authHeaders');
+
+        $this->assertSame(['X-API-Key: s3cret-key'], $headers);
+        $this->assertStringNotContainsStringIgnoringCase(
+            'authorization',
+            implode("\n", $headers),
+            'Gluetun does not accept Authorization: Bearer'
+        );
+    }
+
+    public function testNoAuthHeaderWhenKeyIsBlank(): void
+    {
+        foreach (['', null] as $blank) {
+            $headers = $this->invokePrivate($this->makeClient($blank), 'authHeaders');
+            $this->assertSame([], $headers);
+        }
+    }
+
+    public function testStatusPathsAreUnifiedFirstWithNoWireguardEndpoint(): void
+    {
+        $paths = $this->invokePrivate($this->makeClient(null), 'statusPaths');
+
+        $this->assertSame(['/v1/vpn/status', '/v1/openvpn/status'], $paths);
+        $this->assertNoWireguardPath($paths);
+    }
+
+    public function testPortPathsAreUnifiedFirstWithNoWireguardEndpoint(): void
+    {
+        $paths = $this->invokePrivate($this->makeClient(null), 'portPaths');
+
+        $this->assertSame(['/v1/portforward', '/v1/openvpn/portforwarded'], $paths);
+        $this->assertNoWireguardPath($paths);
+    }
+
+    private function assertNoWireguardPath(array $paths): void
+    {
+        foreach ($paths as $path) {
+            $this->assertStringNotContainsString(
+                '/wireguard/',
+                $path,
+                'Gluetun does not have /v1/wireguard/* control endpoints.'
+            );
+        }
+    }
+}

--- a/symfony/translations/messages+intl-icu.en.yaml
+++ b/symfony/translations/messages+intl-icu.en.yaml
@@ -302,11 +302,9 @@ setup:
         section_suffix: 'VPN — optional'
         subtitle: 'Leave blank if qBittorrent does not route through a VPN.'
         url: URL (Control Server)
-        protocol: Protocol
-        protocol_auto: Auto
         api_key: API key
         api_key_optional: (optional)
-        api_key_placeholder: 'Bearer token if the Control Server is protected'
+        api_key_placeholder: 'X-API-Key value if the Control Server is protected'
     finish:
       eyebrow: 'Step 7 of 7'
       title: "You're all set!"
@@ -701,7 +699,6 @@ admin:
     api_key: API key
     username: Username
     password: Password
-    protocol: 'Protocol (openvpn/wireguard)'
     api_key_if_protected: 'API key (if protected)'
     clear: Clear
     tmdb:

--- a/symfony/translations/messages+intl-icu.fr.yaml
+++ b/symfony/translations/messages+intl-icu.fr.yaml
@@ -301,11 +301,9 @@ setup:
         section_suffix: 'VPN — optionnel'
         subtitle: 'Laissez vide si qBittorrent ne passe pas par un VPN.'
         url: URL (Control Server)
-        protocol: Protocole
-        protocol_auto: Auto
         api_key: Clé API
         api_key_optional: (optionnel)
-        api_key_placeholder: 'Bearer token si le Control Server est protégé'
+        api_key_placeholder: 'Valeur X-API-Key si le Control Server est protégé'
     finish:
       eyebrow: 'Étape 7 sur 7'
       title: 'Tout est prêt !'
@@ -700,7 +698,6 @@ admin:
     api_key: Clé API
     username: Utilisateur
     password: Mot de passe
-    protocol: 'Protocole (openvpn/wireguard)'
     api_key_if_protected: 'Clé API (si protégé)'
     clear: Effacer
     tmdb:


### PR DESCRIPTION
<!--
Thanks for contributing to Prismarr!

Before submitting, please make sure you've read CONTRIBUTING.md and that
`make check` passes locally. The golden rules (CONTRIBUTING.md § Absolute
golden rules) are non-negotiable.
-->

## What does this PR do?

<!-- One or two sentences. Link to the related issue if any. -->

The Gluetun client authenticated with `Authorization: Bearer <key>`, but Gluetun reads the API key from the `X-API-Key` header. Thus, the VPN card only worked when there was no key.

Also removed the `/v1/wireguard/status` and `/v1/wireguard/portforwarded` endpoints, which do not exist. The WireGuard and OpenVPN were both underneath the `/v1/openvpn` endpoint in the [older versions](https://github.com/qdm12/gluetun-wiki/blob/7025b1c0e4427d4477e47d4bbd2ef3f1b5c4da71/setup/advanced/control-server.md#openvpn-and-wireguard). Since they were both under one endpoint anyway, the protocol selector is redundant and was removed.

## Type of change

- [X] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (requires a migration plan - see CONTRIBUTING.md golden rule #3)
- [ ] Documentation only

## Definition of Done checklist

See `CONTRIBUTING.md` for the full list.

- [X] The feature works end-to-end, tested manually in a running container
- [X] No `console.log`, `dd()`, `var_dump`, `TODO`, `FIXME` leftover
- [X] Comments are in English
- [X] **Zero credentials** in code, commits, logs, or docs
- [ ] At least one unit test for new business logic (N/A)
- [X] If this is a bug fix: a regression test that reproduces the bug is included
- [X] `make check` passes locally
- [ ] If an entity was modified: a new migration is committed (N/A)
- [X] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] `README.md` updated if user-facing behaviour changed (N/A)

## Notes for the reviewer

- Sorry if the test file is bad.
- I tested manually on the latest Gluetun container, but not on any older versions.