### PR TITLE
ci: modernise GitHub Actions versions and add fork-friendly guards

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -31,13 +31,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up QEMU (arm64 emulation)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Resolve image name
         id: image
@@ -50,13 +50,13 @@ jobs:
         run: echo "version=${BETA_VERSION_BASE}-beta.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/frankenphp/Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 # Cancel any in-progress run for the same ref when a new push lands.
 concurrency:
@@ -21,7 +22,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # docker-compose.yml expects an env file even when it's empty.
       - name: Create empty env file

--- a/.github/workflows/dockerhub-readme.yml
+++ b/.github/workflows/dockerhub-readme.yml
@@ -17,6 +17,10 @@ on:
 jobs:
   sync:
     name: Push README to Docker Hub
+    # Only the canonical upstream repo holds the Docker Hub secrets. Forks
+    # (e.g. ndandan/Prismarr, which publishes to GHCR instead) skip this job
+    # so a README change doesn't leave a red ✗ on a missing-secret failure.
+    if: github.repository == 'Shoshuo/Prismarr'
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -36,7 +40,7 @@ jobs:
             README.md
 
       - name: Push to Docker Hub
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,13 +35,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up QEMU (arm64 emulation)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Resolve image name
         id: image
@@ -56,7 +56,7 @@ jobs:
 
       - name: Docker metadata (tags + labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ steps.image.outputs.name }}
           tags: |
@@ -75,13 +75,13 @@ jobs:
             org.opencontainers.image.version=${{ github.ref_name }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push (linux/amd64 + linux/arm64)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/frankenphp/Dockerfile
@@ -113,7 +113,7 @@ jobs:
           echo "path=release-notes.md" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: Prismarr ${{ github.ref_name }}
           body_path: ${{ steps.notes.outputs.path }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Prismarr are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Contributor
+- **CI / release workflows modernised.** Bumped the pinned GitHub Actions to current majors (`checkout@v5`, `setup-qemu@v4`, `setup-buildx@v4`, `login@v4`, `metadata@v6`, `build-push@v7`, `dockerhub-description@v5`, `action-gh-release@v3`) across `ci`, `beta`, `release` and `dockerhub-readme`, added a `workflow_dispatch` trigger to `ci` so the suite can be run on demand, and guarded the Docker Hub README sync with `if: github.repository == 'Shoshuo/Prismarr'` so forks don't fail the job on missing secrets.
+
 ## [1.1.1] - 2026-06-10
 
 ### Fixed


### PR DESCRIPTION
## What

Modernise the GitHub Actions workflows so builds keep running as older action majors are deprecated, plus two small fork-friendliness fixes.

### Action version bumps (across `ci`, `beta`, `release`, `dockerhub-readme`)
- `actions/checkout` v4 → **v5**
- `docker/setup-qemu-action` v3 → **v4**
- `docker/setup-buildx-action` v3 → **v4**
- `docker/login-action` v3 → **v4**
- `docker/metadata-action` v5 → **v6**
- `docker/build-push-action` v6 → **v7**
- `peter-evans/dockerhub-description` v4 → **v5**
- `softprops/action-gh-release` v2 → **v3**

### Behavioural tweaks
- **`ci.yml`** — added a `workflow_dispatch` trigger so the check suite can be re-run on demand from the Actions tab (handy when a flake needs a re-run without an empty commit).
- **`dockerhub-readme.yml`** — guarded the sync job with `if: github.repository == 'Shoshuo/Prismarr'`. Forks don't hold the `DOCKERHUB_*` secrets, so a README change there currently leaves a red ✗ on a missing-secret failure; the guard makes the job a clean no-op on forks while remaining unconditionally active on the canonical repo.

## Why

Routine maintenance — pinned actions go stale and start emitting deprecation warnings (and eventually stop running). The fork guard is a courtesy so anyone tracking the repo doesn't get spurious red checks.

## Definition of Done

- Pure CI/workflow change — no application code, so no new tests apply. The `make check` suite is unchanged and green (verified on a PR run of the updated `ci.yml`).
- No credentials, no migrations, no security-surface changes.
- `CHANGELOG.md` updated under `[Unreleased] → Contributor`.

> Scoped intentionally: a separate GHCR publish workflow used for self-hosted testing on my fork is **not** included here, since upstream publishes to Docker Hub.
