### PR TITLE
fix(search): keep the global search icon from overlapping text in compact density

### DIFF
--- a/symfony/templates/base.html.twig
+++ b/symfony/templates/base.html.twig
@@ -102,7 +102,9 @@
     body.density-compact .card-body { padding: .7rem .85rem; }
     body.density-compact .list-group-item { padding: .45rem .75rem; }
     body.density-compact .row.g-3 > *, body.density-compact .row.g-2 > * { padding-top: .35rem; padding-bottom: .35rem; }
-    body.density-compact .form-control,
+    /* The global search input keeps fixed horizontal padding for its
+       absolutely-positioned icon, so it is exempt from the compact shrink. */
+    body.density-compact .form-control:not(.prismarr-search-input),
     body.density-compact .form-select { padding: .35rem .55rem; }
 
     /* Toasts off (opt-out via display_toasts = '0') — JS also guards, this


### PR DESCRIPTION
## What

In **compact density**, the global top-bar search input's placeholder text slides underneath its magnifying-glass icon.

## Why

The search input reserves `padding-left: 2.75rem` for its absolutely-positioned icon (`.prismarr-search-input`). But the compact-density rule

```css
body.density-compact .form-control,
body.density-compact .form-select { padding: .35rem .55rem; }
```

has higher specificity (`body.density-compact .form-control` = `0,2,1` vs `.prismarr-search-input` = `0,1,0`), so in compact mode it overrides the reserved padding down to `.55rem` and the placeholder renders on top of the icon. (Comfortable density is unaffected — there the input's own rule wins by source order.)

## Fix

Exempt the search input from the compact shrink so its fixed icon padding always applies:

```css
body.density-compact .form-control:not(.prismarr-search-input),
body.density-compact .form-select { padding: .35rem .55rem; }
```

One-line CSS change in `base.html.twig` — no JS/PHP/Twig logic touched.

## Verified

Confirmed in-browser in compact density: computed `padding-left` goes `8.8px` → `44px` (2.75rem), leaving an ~11.6px gap between the icon and the text. No regression in comfortable density.

🤖 Generated with [Claude Code](https://claude.com/claude-code)