### PR TITLE
fix(templates): respect reverse-proxy path prefix in hardcoded JS/URLs

### DIFF
--- a/symfony/templates/_quicklook.html.twig
+++ b/symfony/templates/_quicklook.html.twig
@@ -80,6 +80,7 @@
 
 <script>
   (function () {
+    var BASE = window.BASE_PATH;
     // ── Quick-look modal: delegated open + fetch + manual show/hide.
     // Tiles carry [data-ql-trigger] + data-ql-source/type/slug/id and keep
     // their href as a no-JS fallback. We intercept the click, open the shell,
@@ -134,7 +135,7 @@
     // per-open wiring is needed at the call sites.
     window._prismarrWatchlist = window._prismarrWatchlist || {};
     if (!window._prismarrWatchlistReady) {
-      window._prismarrWatchlistReady = fetch('/decouverte/watchlist/status', { credentials: 'same-origin' })
+      window._prismarrWatchlistReady = fetch(BASE + '/decouverte/watchlist/status', { credentials: 'same-origin' })
         .then(function (r) { return r.json(); })
         .then(function (d) { window._prismarrWatchlist = d.index || {}; return window._prismarrWatchlist; })
         .catch(function () { return window._prismarrWatchlist; });
@@ -164,10 +165,10 @@
       var type = t.getAttribute('data-ql-type');
       var id = t.getAttribute('data-ql-id');
       if (!type || !id) return null;
-      if (src === 'tmdb') { return '/tableau-de-bord/quicklook/tmdb/' + type + '/' + id; }
+      if (src === 'tmdb') { return BASE + '/tableau-de-bord/quicklook/tmdb/' + type + '/' + id; }
       var slug = t.getAttribute('data-ql-slug');
       if (!slug) return null;
-      return '/tableau-de-bord/quicklook/' + type + '/' + slug + '/' + id;
+      return BASE + '/tableau-de-bord/quicklook/' + type + '/' + slug + '/' + id;
     }
 
     if (!window._qlDelegated) {
@@ -211,7 +212,7 @@
         var willAdd = !wasIn;
         if (willAdd) { window._prismarrWatchlist[key] = true; } else { delete window._prismarrWatchlist[key]; }
         qlSetWl(btn, willAdd);
-        fetch('/decouverte/watchlist/toggle', {
+        fetch(BASE + '/decouverte/watchlist/toggle', {
           method: 'POST', credentials: 'same-origin',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -248,7 +249,7 @@
         var orig = btn.innerHTML;
         btn.disabled = true;
         btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>';
-        fetch('/decouverte/resolve/' + type + '/' + id, { credentials: 'same-origin' })
+        fetch(BASE + '/decouverte/resolve/' + type + '/' + id, { credentials: 'same-origin' })
           .then(function (r) { return r.json(); })
           .then(function (data) {
             if (!data || data.error) { btn.disabled = false; btn.innerHTML = orig; return; }

--- a/symfony/templates/base.html.twig
+++ b/symfony/templates/base.html.twig
@@ -1423,6 +1423,7 @@
   {% block javascripts %}{% endblock %}
   <script>
   (function () {
+    var BASE = '{{ app.request.getBasePath() }}';
     function initAutohide() {
       document.querySelectorAll('.js-autohide').forEach(function (el) {
         if (el.dataset.autohideInit) return;
@@ -1619,11 +1620,53 @@
       var lastLocal = [];
       var lastOnline = [];
 
+      function openDetailFor(item) {
+        if (!window.prismarrQl) return;
+        var isFilm = item.type === 'film';
+        var url;
+        if (item.inLibrary && item.instance && item.instance.slug && item.id) {
+          // Local library result — authoritative Radarr/Sonarr data + Manage deep-link.
+          url = BASE + '/tableau-de-bord/quicklook/' + (isFilm ? 'movie' : 'series')
+              + '/' + item.instance.slug + '/' + item.id;
+        } else {
+          // Online result — TMDb data. Movies key on tmdbId (== id); series need tmdbId.
+          var tmdbId = item.tmdbId || (isFilm ? item.id : null);
+          if (!tmdbId) {
+            // No TMDb id (e.g. TVDB-only series) → can't show TMDb detail.
+            // Fall back to the existing quick-add flow so the user can still add it.
+            closeResults();
+            var trigger = document.createElement('a');
+            trigger.href = '#';
+            trigger.setAttribute('data-quick-add', JSON.stringify(item));
+            trigger.style.display = 'none';
+            document.body.appendChild(trigger);
+            trigger.click();           // bubbles to the document-level [data-quick-add] handler
+            trigger.remove();
+            return;
+          }
+          url = BASE + '/tableau-de-bord/quicklook/tmdb/' + (isFilm ? 'movie' : 'tv') + '/' + tmdbId;
+        }
+        closeResults();
+        window.prismarrQl.open();
+        fetch(url, { headers: { 'X-Requested-With': 'fetch' }, credentials: 'same-origin' })
+          .then(function (r) { return r.ok ? r.text() : ''; })
+          .then(function (html) {
+            var b = window.prismarrQl.body();
+            if (!b) return;
+            b.innerHTML = (html || '').trim() || '<div class="ql-error"></div>';
+            // The quick-look body now renders the correct primary action
+            // server-side (Manage deep-link to the exact instance when the
+            // title is in a library, otherwise an Add button wired to the
+            // shared resolve→quick-add flow), so no client-side patching is
+            // needed here.
+          })
+          .catch(function () { window.prismarrQl.close(); });
+      }
       function runSearch(q) {
         showSpinner();
         var ctrl = new AbortController();
         currentReq = ctrl;
-        fetch('/medias/' + DEFAULT_RADARR_SLUG + '/search?q=' + encodeURIComponent(q), { signal: ctrl.signal })
+        fetch(BASE + '/medias/' + DEFAULT_RADARR_SLUG + '/search?q=' + encodeURIComponent(q), { signal: ctrl.signal })
           .then(function (r) { return r.json(); })
           .then(function (localItems) {
             hideSpinner();
@@ -1633,7 +1676,7 @@
 
             var ctrl2 = new AbortController();
             onlineReq = ctrl2;
-            fetch('/medias/' + DEFAULT_RADARR_SLUG + '/search/online?q=' + encodeURIComponent(q), { signal: ctrl2.signal })
+            fetch(BASE + '/medias/' + DEFAULT_RADARR_SLUG + '/search/online?q=' + encodeURIComponent(q), { signal: ctrl2.signal })
               .then(function (r) { return r.json(); })
               .then(function (onlineItems) {
                 onlineReq = null;
@@ -1790,11 +1833,11 @@
           return Promise.resolve();
         }
         var profileUrl = isFilm
-          ? '/medias/' + slug + '/films/quality-profiles'
-          : '/medias/' + slug + '/sonarr/quality-profiles';
+          ? BASE + '/medias/' + slug + '/films/quality-profiles'
+          : BASE + '/medias/' + slug + '/sonarr/quality-profiles';
         var folderUrl = isFilm
-          ? '/medias/' + slug + '/films/root-folders'
-          : '/medias/' + slug + '/sonarr/root-folders';
+          ? BASE + '/medias/' + slug + '/films/root-folders'
+          : BASE + '/medias/' + slug + '/sonarr/root-folders';
         return Promise.all([
           fetch(profileUrl).then(function (r) { return r.json(); }),
           fetch(folderUrl).then(function (r) { return r.json(); })
@@ -1819,7 +1862,7 @@
         var rows = instances.map(function (inst) {
           var lbl = statusLabels[inst.status] || inst.status;
           var openLbl = i18n['qa.action.view'] || 'Voir';
-          var url = '/medias/' + inst.slug + (isFilm ? '/films?open=' : '/series?open=') + inst.id;
+          var url = BASE + '/medias/' + inst.slug + (isFilm ? '/films?open=' : '/series?open=') + inst.id;
           return '<div class="d-flex align-items-center gap-2 p-2 mb-1 rounded" style="background:rgba(255,255,255,.04);">'
             + '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2.5"><path d="M5 12l5 5l10-10"/></svg>'
             + '<span class="small fw-medium">' + window.escHtml(inst.name) + '</span>'
@@ -1889,7 +1932,7 @@
         // falls back to default-only behaviour so the modal still works.
         var resolveType = isFilm ? 'movie' : 'tv';
         var resolveId   = qaItem.tmdbId || qaItem.id;
-        fetch('/decouverte/resolve/' + resolveType + '/' + resolveId)
+        fetch(BASE + '/decouverte/resolve/' + resolveType + '/' + resolveId)
           .then(function (r) { return r.json(); })
           .then(function (resolved) {
             var defaultSlug = isFilm ? DEFAULT_RADARR_SLUG : DEFAULT_SONARR_SLUG;
@@ -2027,7 +2070,7 @@
         var targetSlug = qaSelectedSlug || (isFilm ? DEFAULT_RADARR_SLUG : DEFAULT_SONARR_SLUG);
         var url, payload;
         if (isFilm) {
-          url = '/medias/' + targetSlug + '/films/add';
+          url = BASE + '/medias/' + targetSlug + '/films/add';
           payload = {
             tmdbId: qaItem.id, title: qaItem.title, year: qaItem.year || 0,
             qualityProfileId: parseInt(qualVal), rootFolderPath: folderVal,
@@ -2036,7 +2079,7 @@
             searchForMovie: document.getElementById('qa-film-search').checked
           };
         } else {
-          url = '/medias/' + targetSlug + '/series/add';
+          url = BASE + '/medias/' + targetSlug + '/series/add';
           payload = {
             tvdbId: qaItem.id, title: qaItem.title,
             qualityProfileId: parseInt(qualVal), rootFolderPath: folderVal,
@@ -2641,7 +2684,7 @@
       }
 
       function fetchHealth() {
-        fetch('/api/health/services', { credentials: 'same-origin', headers: { 'Accept': 'application/json' } })
+        fetch('{{ path('api_health_services') }}', { credentials: 'same-origin', headers: { 'Accept': 'application/json' } })
           .then(function (r) { return r.ok ? r.json() : null; })
           .then(function (d) { if (d) renderHealth(d); })
           .catch(function () {});

--- a/symfony/templates/base.html.twig
+++ b/symfony/templates/base.html.twig
@@ -41,6 +41,10 @@
     window.INSTANCE_SLUG = INSTANCE_SLUG;
     window.DEFAULT_RADARR_SLUG = DEFAULT_RADARR_SLUG;
     window.DEFAULT_SONARR_SLUG = DEFAULT_SONARR_SLUG;
+    // Reverse-proxy path prefix, exposed once here so every child template's
+    // `var BASE = window.BASE_PATH;` reads the same value instead of each
+    // re-evaluating app.request.getBasePath() in its own script block.
+    window.BASE_PATH = {{ app.request.getBasePath()|json_encode|raw }};
 
     // Global locale-aware byte formatter — must be defined here in <head>
     // BEFORE any child template's javascripts block runs. The original
@@ -1500,6 +1504,7 @@
   {% block javascripts %}{% endblock %}
   <script>
   (function () {
+    var BASE = window.BASE_PATH;
     function initAutohide() {
       document.querySelectorAll('.js-autohide').forEach(function (el) {
         if (el.dataset.autohideInit) return;
@@ -1702,7 +1707,7 @@
         var url;
         if (item.inLibrary && item.instance && item.instance.slug && item.id) {
           // Local library result — authoritative Radarr/Sonarr data + Manage deep-link.
-          url = '/tableau-de-bord/quicklook/' + (isFilm ? 'movie' : 'series')
+          url = BASE + '/tableau-de-bord/quicklook/' + (isFilm ? 'movie' : 'series')
               + '/' + item.instance.slug + '/' + item.id;
         } else {
           // Online result — TMDb data. Movies key on tmdbId (== id); series need tmdbId.
@@ -1720,7 +1725,7 @@
             trigger.remove();
             return;
           }
-          url = '/tableau-de-bord/quicklook/tmdb/' + (isFilm ? 'movie' : 'tv') + '/' + tmdbId;
+          url = BASE + '/tableau-de-bord/quicklook/tmdb/' + (isFilm ? 'movie' : 'tv') + '/' + tmdbId;
         }
         closeResults();
         window.prismarrQl.open();
@@ -1738,12 +1743,11 @@
           })
           .catch(function () { window.prismarrQl.close(); });
       }
-
       function runSearch(q) {
         showSpinner();
         var ctrl = new AbortController();
         currentReq = ctrl;
-        fetch('/medias/' + DEFAULT_RADARR_SLUG + '/search?q=' + encodeURIComponent(q), { signal: ctrl.signal })
+        fetch(BASE + '/medias/' + DEFAULT_RADARR_SLUG + '/search?q=' + encodeURIComponent(q), { signal: ctrl.signal })
           .then(function (r) { return r.json(); })
           .then(function (localItems) {
             hideSpinner();
@@ -1753,7 +1757,7 @@
 
             var ctrl2 = new AbortController();
             onlineReq = ctrl2;
-            fetch('/medias/' + DEFAULT_RADARR_SLUG + '/search/online?q=' + encodeURIComponent(q), { signal: ctrl2.signal })
+            fetch(BASE + '/medias/' + DEFAULT_RADARR_SLUG + '/search/online?q=' + encodeURIComponent(q), { signal: ctrl2.signal })
               .then(function (r) { return r.json(); })
               .then(function (onlineItems) {
                 onlineReq = null;
@@ -1913,11 +1917,11 @@
           return Promise.resolve();
         }
         var profileUrl = isFilm
-          ? '/medias/' + slug + '/films/quality-profiles'
-          : '/medias/' + slug + '/sonarr/quality-profiles';
+          ? BASE + '/medias/' + slug + '/films/quality-profiles'
+          : BASE + '/medias/' + slug + '/sonarr/quality-profiles';
         var folderUrl = isFilm
-          ? '/medias/' + slug + '/films/root-folders'
-          : '/medias/' + slug + '/sonarr/root-folders';
+          ? BASE + '/medias/' + slug + '/films/root-folders'
+          : BASE + '/medias/' + slug + '/sonarr/root-folders';
         return Promise.all([
           fetch(profileUrl).then(function (r) { return r.json(); }),
           fetch(folderUrl).then(function (r) { return r.json(); })
@@ -1942,7 +1946,7 @@
         var rows = instances.map(function (inst) {
           var lbl = statusLabels[inst.status] || inst.status;
           var openLbl = i18n['qa.action.view'] || 'Voir';
-          var url = '/medias/' + inst.slug + (isFilm ? '/films?open=' : '/series?open=') + inst.id;
+          var url = BASE + '/medias/' + inst.slug + (isFilm ? '/films?open=' : '/series?open=') + inst.id;
           return '<div class="d-flex align-items-center gap-2 p-2 mb-1 rounded" style="background:rgba(255,255,255,.04);">'
             + '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2.5"><path d="M5 12l5 5l10-10"/></svg>'
             + '<span class="small fw-medium">' + window.escHtml(inst.name) + '</span>'
@@ -2013,7 +2017,7 @@
         // falls back to default-only behaviour so the modal still works.
         var resolveType = isFilm ? 'movie' : 'tv';
         var resolveId   = qaItem.tmdbId || qaItem.id;
-        fetch('/decouverte/resolve/' + resolveType + '/' + resolveId)
+        fetch(BASE + '/decouverte/resolve/' + resolveType + '/' + resolveId)
           .then(function (r) { return r.json(); })
           .then(function (resolved) {
             var defaultSlug = isFilm ? DEFAULT_RADARR_SLUG : DEFAULT_SONARR_SLUG;
@@ -2151,7 +2155,7 @@
         var targetSlug = qaSelectedSlug || (isFilm ? DEFAULT_RADARR_SLUG : DEFAULT_SONARR_SLUG);
         var url, payload;
         if (isFilm) {
-          url = '/medias/' + targetSlug + '/films/add';
+          url = BASE + '/medias/' + targetSlug + '/films/add';
           payload = {
             tmdbId: qaItem.id, title: qaItem.title, year: qaItem.year || 0,
             qualityProfileId: parseInt(qualVal), rootFolderPath: folderVal,
@@ -2160,7 +2164,7 @@
             searchForMovie: document.getElementById('qa-film-search').checked
           };
         } else {
-          url = '/medias/' + targetSlug + '/series/add';
+          url = BASE + '/medias/' + targetSlug + '/series/add';
           payload = {
             tvdbId: qaItem.id, title: qaItem.title,
             qualityProfileId: parseInt(qualVal), rootFolderPath: folderVal,
@@ -3120,7 +3124,7 @@
       }
 
       function fetchHealth() {
-        fetch('/api/health/services', { credentials: 'same-origin', headers: { 'Accept': 'application/json' } })
+        fetch('{{ path('api_health_services') }}', { credentials: 'same-origin', headers: { 'Accept': 'application/json' } })
           .then(function (r) { return r.ok ? r.json() : null; })
           .then(function (d) { if (d) renderHealth(d); })
           .catch(function () {});

--- a/symfony/templates/calendrier/index.html.twig
+++ b/symfony/templates/calendrier/index.html.twig
@@ -378,6 +378,7 @@
 {% block javascripts %}
 <script>
 (function () {
+    var BASE = '{{ app.request.getBasePath() }}';
     var allEvents = {{ eventsJson|json_encode|raw }};
     // Calendar-scoped i18n (strings the JS renders on the fly).
     var CAL_I18N = {
@@ -914,10 +915,10 @@
         // cached JSON or edge case with empty libraries).
         if (ev.type === 'film' && ev.id) {
             var radarrSlug = ev._instanceSlug || DEFAULT_RADARR_SLUG;
-            target = '/medias/' + radarrSlug + '/films?open=' + ev.id;
+            target = BASE + '/medias/' + radarrSlug + '/films?open=' + ev.id;
         } else if (ev.type === 'episode' && ev.seriesId) {
             var sonarrSlug = ev._instanceSlug || DEFAULT_SONARR_SLUG;
-            target = '/medias/' + sonarrSlug + '/series?open=' + ev.seriesId;
+            target = BASE + '/medias/' + sonarrSlug + '/series?open=' + ev.seriesId;
         }
         if (target) {
             e.preventDefault();

--- a/symfony/templates/calendrier/index.html.twig
+++ b/symfony/templates/calendrier/index.html.twig
@@ -378,6 +378,7 @@
 {% block javascripts %}
 <script>
 (function () {
+    var BASE = window.BASE_PATH;
     var allEvents = {{ eventsJson|json_encode|raw }};
     // Calendar-scoped i18n (strings the JS renders on the fly).
     var CAL_I18N = {
@@ -914,10 +915,10 @@
         // cached JSON or edge case with empty libraries).
         if (ev.type === 'film' && ev.id) {
             var radarrSlug = ev._instanceSlug || DEFAULT_RADARR_SLUG;
-            target = '/medias/' + radarrSlug + '/films?open=' + ev.id;
+            target = BASE + '/medias/' + radarrSlug + '/films?open=' + ev.id;
         } else if (ev.type === 'episode' && ev.seriesId) {
             var sonarrSlug = ev._instanceSlug || DEFAULT_SONARR_SLUG;
-            target = '/medias/' + sonarrSlug + '/series?open=' + ev.seriesId;
+            target = BASE + '/medias/' + sonarrSlug + '/series?open=' + ev.seriesId;
         }
         if (target) {
             e.preventDefault();

--- a/symfony/templates/dashboard/_plex_info_modal.html.twig
+++ b/symfony/templates/dashboard/_plex_info_modal.html.twig
@@ -17,6 +17,7 @@
 (function () {
   if (window._plexModalDelegated) return;
   window._plexModalDelegated = true;
+  var BASE = '{{ app.request.getBasePath() }}';
   function openPlexModal(ratingKey, player, device) {
     var modalEl = document.getElementById('plex-info-modal');
     var trigger = document.querySelector('[data-plex-modal-trigger]');
@@ -24,7 +25,7 @@
     var body = modalEl.querySelector('[data-plex-modal-body]');
     body.innerHTML = '<div class="modal-body text-center py-5"><span class="spinner-border"></span></div>';
     trigger.click();
-    var url = '/tautulli/api/metadata/' + encodeURIComponent(ratingKey)
+    var url = BASE + '/tautulli/api/metadata/' + encodeURIComponent(ratingKey)
       + '?player=' + encodeURIComponent(player || '') + '&device=' + encodeURIComponent(device || '');
     fetch(url, { headers: { 'X-Requested-With': 'fetch' }, credentials: 'same-origin' })
       .then(function (r) { return r.ok ? r.text() : ''; })

--- a/symfony/templates/dashboard/_plex_info_modal.html.twig
+++ b/symfony/templates/dashboard/_plex_info_modal.html.twig
@@ -24,6 +24,7 @@
 (function () {
   if (window._plexModalDelegated) return;
   window._plexModalDelegated = true;
+  var BASE = window.BASE_PATH;
   function openPlexModal(ratingKey, player, device) {
     var modalEl = document.getElementById('plex-info-modal');
     var trigger = document.querySelector('[data-plex-modal-trigger]');
@@ -31,7 +32,7 @@
     var body = modalEl.querySelector('[data-plex-modal-body]');
     body.innerHTML = '<div class="modal-body text-center py-5"><span class="spinner-border"></span></div>';
     trigger.click();
-    var url = '/tautulli/api/metadata/' + encodeURIComponent(ratingKey)
+    var url = BASE + '/tautulli/api/metadata/' + encodeURIComponent(ratingKey)
       + '?player=' + encodeURIComponent(player || '') + '&device=' + encodeURIComponent(device || '');
     fetch(url, { headers: { 'X-Requested-With': 'fetch' }, credentials: 'same-origin' })
       .then(function (r) { return r.ok ? r.text() : ''; })
@@ -43,7 +44,7 @@
     var legacy = function () {
       openPlexModal(ratingKey, t.getAttribute('data-plex-player'), t.getAttribute('data-plex-device'));
     };
-    fetch('/tautulli/api/quicklook/' + encodeURIComponent(ratingKey), { headers: { 'X-Requested-With': 'fetch' }, credentials: 'same-origin' })
+    fetch(BASE + '/tautulli/api/quicklook/' + encodeURIComponent(ratingKey), { headers: { 'X-Requested-With': 'fetch' }, credentials: 'same-origin' })
       .then(function (r) { return r.ok ? r.json() : null; })
       .then(function (d) {
         var ghost = document.querySelector('[data-plex-ql-ghost]');
@@ -52,7 +53,7 @@
         ghost.setAttribute('data-ql-id', String(d.id));
         // Real deep-link href: the global handler navigates here if the
         // quick-look fragment fetch itself fails (same as watchlist tiles).
-        ghost.setAttribute('href', '/decouverte?detail=' + d.type + '/' + d.id);
+        ghost.setAttribute('href', BASE + '/decouverte?detail=' + d.type + '/' + d.id);
         ghost.click();
       })
       .catch(legacy);

--- a/symfony/templates/dashboard/index.html.twig
+++ b/symfony/templates/dashboard/index.html.twig
@@ -874,15 +874,16 @@
       if (b) { b.innerHTML = '<div class="ql-loading"><span class="spinner-border"></span></div>'; }
     }
 
+    var BASE = '{{ app.request.getBasePath() }}';
     function qlUrl(t) {
       var src = t.getAttribute('data-ql-source');
       var type = t.getAttribute('data-ql-type');
       var id = t.getAttribute('data-ql-id');
       if (!type || !id) return null;
-      if (src === 'tmdb') { return '/tableau-de-bord/quicklook/tmdb/' + type + '/' + id; }
+      if (src === 'tmdb') { return BASE + '/tableau-de-bord/quicklook/tmdb/' + type + '/' + id; }
       var slug = t.getAttribute('data-ql-slug');
       if (!slug) return null;
-      return '/tableau-de-bord/quicklook/' + type + '/' + slug + '/' + id;
+      return BASE + '/tableau-de-bord/quicklook/' + type + '/' + slug + '/' + id;
     }
 
     if (!window._qlDelegated) {

--- a/symfony/templates/decouverte/explorer.html.twig
+++ b/symfony/templates/decouverte/explorer.html.twig
@@ -295,6 +295,7 @@
 
 <script>
 (function() {
+  var BASE = '{{ app.request.getBasePath() }}';
   function escHtml(s) { if (s == null) return ''; var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
 
   // Localized strings used by the dynamic JS parts of this page.
@@ -495,7 +496,7 @@
 
   function openDetail(type, id) {
     openModal();
-    fetch('/decouverte/detail/' + type + '/' + id, { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/detail/' + type + '/' + id, { credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         if (d.error) { detailLoading.innerHTML = '<div class="alert alert-danger m-3">' + escHtml(d.error) + '</div>'; return; }
@@ -519,7 +520,7 @@
     if (!btn) return;
     e.stopImmediatePropagation();
     var key = btn.dataset.type + '_' + btn.dataset.tmdbId;
-    fetch('/decouverte/watchlist/toggle', {
+    fetch(BASE + '/decouverte/watchlist/toggle', {
       method: 'POST', credentials: 'same-origin',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -564,7 +565,7 @@
   var genrePills = document.getElementById('ex-genre-pills');
 
   function loadGenres(type) {
-    fetch('/decouverte/genres/' + type, { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/genres/' + type, { credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         genrePills.innerHTML = (d.genres || []).map(function(g) {
@@ -623,7 +624,7 @@
     lastParams = info;
     lastLabel = buildLabel(info);
     showSpinner();
-    fetch('/decouverte/filter?' + info.params.toString(), { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/filter?' + info.params.toString(), { credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         totalPages = d.total_pages || 1;
@@ -639,7 +640,7 @@
     loadMoreBtn.disabled = true;
     loadMoreBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>' + EX_I18N.loading;
     var info = buildParams(currentPage);
-    fetch('/decouverte/filter?' + info.params.toString(), { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/filter?' + info.params.toString(), { credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         render(d.results || [], lastLabel, true);
@@ -676,7 +677,7 @@
     var q = colSearch.value.trim();
     if (q.length < 2) { colSugg.innerHTML = ''; return; }
     colTimer = setTimeout(function() {
-      fetch('/decouverte/collection/search?q=' + encodeURIComponent(q), { credentials: 'same-origin' })
+      fetch(BASE + '/decouverte/collection/search?q=' + encodeURIComponent(q), { credentials: 'same-origin' })
         .then(function(r) { return r.json(); })
         .then(function(d) {
           colSugg.innerHTML = (d.results || []).map(function(c) {
@@ -696,7 +697,7 @@
     clearCollectionActive();
     clearPersonHeader();
     showSpinner();
-    fetch('/decouverte/collection/' + s.dataset.colId, { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/collection/' + s.dataset.colId, { credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         if (d.error) { grid.innerHTML = '<div class="ex-empty">' + escHtml(d.error) + '</div>'; return; }
@@ -713,7 +714,7 @@
     clearPersonHeader();
     pill.classList.add('active');
     showSpinner();
-    fetch('/decouverte/collection/' + pill.dataset.colId, { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/collection/' + pill.dataset.colId, { credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         if (d.error) { grid.innerHTML = '<div class="ex-empty">' + escHtml(d.error) + '</div>'; return; }
@@ -738,7 +739,7 @@
     var q = personInput.value.trim();
     if (q.length < 2) { personSugg.innerHTML = ''; return; }
     personTimer = setTimeout(function() {
-      fetch('/decouverte/person/search?q=' + encodeURIComponent(q), { credentials: 'same-origin' })
+      fetch(BASE + '/decouverte/person/search?q=' + encodeURIComponent(q), { credentials: 'same-origin' })
         .then(function(r) { return r.json(); })
         .then(function(d) {
           personSugg.innerHTML = (d.results || []).map(function(p) {
@@ -764,7 +765,7 @@
     else { photo.style.display = 'none'; }
 
     showSpinner();
-    fetch('/decouverte/person/' + s.dataset.personId, { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/person/' + s.dataset.personId, { credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         if (d.error) { grid.innerHTML = '<div class="ex-empty">' + escHtml(d.error) + '</div>'; return; }
@@ -782,7 +783,7 @@
     var origText = btn.innerHTML;
     btn.disabled = true;
     btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>' + EX_I18N.resolving;
-    fetch('/decouverte/resolve/' + btn.dataset.type + '/' + btn.dataset.tmdbId, { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/resolve/' + btn.dataset.type + '/' + btn.dataset.tmdbId, { credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(data) {
         if (data.error) {
@@ -812,7 +813,7 @@
 
   // ── Watchlist ──
   window._prismarrWatchlist = window._prismarrWatchlist || {};
-  fetch('/decouverte/watchlist/status', { credentials: 'same-origin' })
+  fetch(BASE + '/decouverte/watchlist/status', { credentials: 'same-origin' })
     .then(function(r) { return r.json(); })
     .then(function(d) {
       window._prismarrWatchlist = d.index || {};
@@ -851,7 +852,7 @@
     else delete window._prismarrWatchlist[key];
     syncExWlStar(star.dataset.tmdbId, star.dataset.tmdbType, willAdd);
 
-    fetch('/decouverte/watchlist/toggle', {
+    fetch(BASE + '/decouverte/watchlist/toggle', {
       method: 'POST', credentials: 'same-origin',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/symfony/templates/decouverte/explorer.html.twig
+++ b/symfony/templates/decouverte/explorer.html.twig
@@ -253,6 +253,7 @@
 
 <script>
 (function() {
+  var BASE = window.BASE_PATH;
   function escHtml(s) { if (s == null) return ''; var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
 
   // Localized strings used by the dynamic JS parts of this page.
@@ -356,7 +357,7 @@
     if (!card || !window.prismarrQl) return;
     var type = card.dataset.type === 'movie' ? 'movie' : 'tv';
     window.prismarrQl.open();
-    fetch('/tableau-de-bord/quicklook/tmdb/' + type + '/' + card.dataset.tmdbId, { headers: { 'X-Requested-With': 'fetch' }, credentials: 'same-origin' })
+    fetch(BASE + '/tableau-de-bord/quicklook/tmdb/' + type + '/' + card.dataset.tmdbId, { headers: { 'X-Requested-With': 'fetch' }, credentials: 'same-origin' })
       .then(function(r) { return r.ok ? r.text() : ''; })
       .then(function(html) {
         var b = window.prismarrQl.body();
@@ -384,7 +385,7 @@
   var genrePills = document.getElementById('ex-genre-pills');
 
   function loadGenres(type) {
-    fetch('/decouverte/genres/' + type, { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/genres/' + type, { credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         genrePills.innerHTML = (d.genres || []).map(function(g) {
@@ -443,7 +444,7 @@
     lastParams = info;
     lastLabel = buildLabel(info);
     showSpinner();
-    fetch('/decouverte/filter?' + info.params.toString(), { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/filter?' + info.params.toString(), { credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         totalPages = d.total_pages || 1;
@@ -459,7 +460,7 @@
     loadMoreBtn.disabled = true;
     loadMoreBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>' + EX_I18N.loading;
     var info = buildParams(currentPage);
-    fetch('/decouverte/filter?' + info.params.toString(), { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/filter?' + info.params.toString(), { credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         render(d.results || [], lastLabel, true);
@@ -496,7 +497,7 @@
     var q = colSearch.value.trim();
     if (q.length < 2) { colSugg.innerHTML = ''; return; }
     colTimer = setTimeout(function() {
-      fetch('/decouverte/collection/search?q=' + encodeURIComponent(q), { credentials: 'same-origin' })
+      fetch(BASE + '/decouverte/collection/search?q=' + encodeURIComponent(q), { credentials: 'same-origin' })
         .then(function(r) { return r.json(); })
         .then(function(d) {
           colSugg.innerHTML = (d.results || []).map(function(c) {
@@ -516,7 +517,7 @@
     clearCollectionActive();
     clearPersonHeader();
     showSpinner();
-    fetch('/decouverte/collection/' + s.dataset.colId, { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/collection/' + s.dataset.colId, { credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         if (d.error) { grid.innerHTML = '<div class="ex-empty">' + escHtml(d.error) + '</div>'; return; }
@@ -533,7 +534,7 @@
     clearPersonHeader();
     pill.classList.add('active');
     showSpinner();
-    fetch('/decouverte/collection/' + pill.dataset.colId, { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/collection/' + pill.dataset.colId, { credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         if (d.error) { grid.innerHTML = '<div class="ex-empty">' + escHtml(d.error) + '</div>'; return; }
@@ -558,7 +559,7 @@
     var q = personInput.value.trim();
     if (q.length < 2) { personSugg.innerHTML = ''; return; }
     personTimer = setTimeout(function() {
-      fetch('/decouverte/person/search?q=' + encodeURIComponent(q), { credentials: 'same-origin' })
+      fetch(BASE + '/decouverte/person/search?q=' + encodeURIComponent(q), { credentials: 'same-origin' })
         .then(function(r) { return r.json(); })
         .then(function(d) {
           personSugg.innerHTML = (d.results || []).map(function(p) {
@@ -584,7 +585,7 @@
     else { photo.style.display = 'none'; }
 
     showSpinner();
-    fetch('/decouverte/person/' + s.dataset.personId, { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/person/' + s.dataset.personId, { credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         if (d.error) { grid.innerHTML = '<div class="ex-empty">' + escHtml(d.error) + '</div>'; return; }
@@ -596,7 +597,7 @@
   });
   // ── Watchlist ──
   window._prismarrWatchlist = window._prismarrWatchlist || {};
-  fetch('/decouverte/watchlist/status', { credentials: 'same-origin' })
+  fetch(BASE + '/decouverte/watchlist/status', { credentials: 'same-origin' })
     .then(function(r) { return r.json(); })
     .then(function(d) {
       window._prismarrWatchlist = d.index || {};
@@ -635,7 +636,7 @@
     else delete window._prismarrWatchlist[key];
     syncExWlStar(star.dataset.tmdbId, star.dataset.tmdbType, willAdd);
 
-    fetch('/decouverte/watchlist/toggle', {
+    fetch(BASE + '/decouverte/watchlist/toggle', {
       method: 'POST', credentials: 'same-origin',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/symfony/templates/decouverte/index.html.twig
+++ b/symfony/templates/decouverte/index.html.twig
@@ -991,7 +991,7 @@
           {% set statusColors = {'downloaded':'#22c55e','missing':'#f59e0b','announced':'#6366f1','inCinemas':'#6366f1','partial':'#3b82f6','unmonitored':'#6b7280'} %}
           {% set statusKey = 'decouverte.modal.status.' ~ (item.lib_status ?: 'downloaded') %}
           {% set statusLabel = item.lib_status ? statusKey|trans : 'decouverte.card.in_library_short'|trans %}
-          <a href="{{ (item.type == 'movie' ? '/medias/' ~ current_slug('radarr') ~ '/films' : '/medias/' ~ current_slug('sonarr') ~ '/series') ~ '?open=' ~ item.lib_id }}" class="btn btn-sm" style="background:{{ statusColors[item.lib_status] ?? '#22c55e' }};color:#fff;">{{ statusLabel }}</a>
+          <a href="{{ (item.type == 'movie' ? app.request.getBasePath() ~ '/medias/' ~ current_slug('radarr') ~ '/films' : app.request.getBasePath() ~ '/medias/' ~ current_slug('sonarr') ~ '/series') ~ '?open=' ~ item.lib_id }}" class="btn btn-sm" style="background:{{ statusColors[item.lib_status] ?? '#22c55e' }};color:#fff;">{{ statusLabel }}</a>
         {% endif %}
       </div>
     </div>
@@ -1000,6 +1000,7 @@
 
 <script>
 (function() {
+  var BASE = '{{ app.request.getBasePath() }}';
   function escHtml(s) { var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
 
   // Localized strings used by the detail modal + toasts. Built server-side
@@ -1185,7 +1186,7 @@
     btn.disabled = true;
     btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
 
-    fetch('/decouverte/resolve/' + type + '/' + id, { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/resolve/' + type + '/' + id, { credentials: 'same-origin' })
       .then(function(r) { return r.json().then(function(d) { return { ok: r.ok, body: d }; }); })
       .then(function(res) {
         btn.disabled = false;
@@ -1374,7 +1375,7 @@
       actions.push('<button class="btn btn-primary tmdb-add-btn" data-tmdb-id="' + d.id + '" data-tmdb-type="' + d.type + '" data-tmdb-title="' + safeTitle + '">'
         + '<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="me-1"><path d="M12 5v14"/><path d="M5 12h14"/></svg>' + (d.type === 'movie' ? TMDB_I18N.add_to_radarr : TMDB_I18N.add_to_sonarr) + '</button>');
     } else {
-      var libUrl = d.type === 'movie' ? '/medias/' + DEFAULT_RADARR_SLUG + '/films' : '/medias/' + DEFAULT_SONARR_SLUG + '/series';
+      var libUrl = d.type === 'movie' ? BASE + '/medias/' + DEFAULT_RADARR_SLUG + '/films' : BASE + '/medias/' + DEFAULT_SONARR_SLUG + '/series';
       if (d.lib_id) libUrl += '?open=' + d.lib_id;
       var btnClass = d.lib_status === 'downloaded' ? 'btn-success' : (d.lib_status === 'missing' || d.lib_status === 'partial' ? 'btn-warning' : 'btn-outline-primary');
       actions.push('<a href="' + libUrl + '" class="btn ' + btnClass + '">'
@@ -1759,7 +1760,7 @@
     var libBadge = item.in_library ? '<span class="lib-badge" style="background:' + (statusColors[item.lib_status] || '#22c55e') + ';">' + (cardShort[item.lib_status] || cardShort._default) + '</span>' : '';
     var voteBadge = item.vote ? '<span class="vote-badge ' + vc + '">' + {{ ico.icon('star-filled', '', 12)|json_encode|raw }} + ' ' + item.vote + '</span>' : '';
     var hoverBtn  = item.in_library
-      ? '<a href="' + (item.type === 'movie' ? '/medias/' + DEFAULT_RADARR_SLUG + '/films' : '/medias/' + DEFAULT_SONARR_SLUG + '/series') + '?open=' + (item.lib_id||'') + '" class="btn btn-sm" style="background:' + ({downloaded:'#22c55e',missing:'#f59e0b',announced:'#6366f1',inCinemas:'#6366f1',partial:'#3b82f6',unmonitored:'#6b7280'}[item.lib_status]||'#22c55e') + ';color:#fff;">' + (cardShort[item.lib_status] || inLibraryShort) + '</a>'
+      ? '<a href="' + (item.type === 'movie' ? BASE + '/medias/' + DEFAULT_RADARR_SLUG + '/films' : BASE + '/medias/' + DEFAULT_SONARR_SLUG + '/series') + '?open=' + (item.lib_id||'') + '" class="btn btn-sm" style="background:' + ({downloaded:'#22c55e',missing:'#f59e0b',announced:'#6366f1',inCinemas:'#6366f1',partial:'#3b82f6',unmonitored:'#6b7280'}[item.lib_status]||'#22c55e') + ';color:#fff;">' + (cardShort[item.lib_status] || inLibraryShort) + '</a>'
       : '<button type="button" class="btn btn-primary btn-sm tmdb-add-btn" data-tmdb-id="' + item.id + '" data-tmdb-type="' + item.type + '" data-tmdb-title="' + safeTitle + '">' + {{ 'decouverte.action.add'|trans|json_encode|raw }} + '</button>';
 
     var wlClass = (window._prismarrWatchlist && window._prismarrWatchlist[item.type + '_' + item.id]) ? ' in-wl' : '';
@@ -1791,7 +1792,7 @@
 
   function loadDetail(type, id) {
     openDetailModal();
-    fetch('/decouverte/detail/' + type + '/' + id, { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/detail/' + type + '/' + id, { credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         if (d.error) {
@@ -1831,7 +1832,7 @@
       return;
     }
     searchAbort = new AbortController();
-    fetch('/decouverte/search?q=' + encodeURIComponent(q), { signal: searchAbort.signal, credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/search?q=' + encodeURIComponent(q), { signal: searchAbort.signal, credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         var results = d.results || [];
@@ -1890,7 +1891,7 @@
   // ── Recommendations based on the library (AJAX load on page load)
   var myRecsBlock = document.getElementById('tmdb-my-recs');
   var myRecsRow = document.getElementById('tmdb-my-recs-row');
-  fetch('/decouverte/mes-recommandations', { credentials: 'same-origin' })
+  fetch(BASE + '/decouverte/mes-recommandations', { credentials: 'same-origin' })
     .then(function(r) { return r.json(); })
     .then(function(d) {
       if (d.seeds === 0 || !d.results || !d.results.length) {
@@ -1932,7 +1933,7 @@
   }
 
   function loadGenres(type) {
-    fetch('/decouverte/genres/' + type, { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/genres/' + type, { credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         genresCache[type] = d.genres || [];
@@ -2005,7 +2006,7 @@
     searchGrid.innerHTML = '<div class="text-secondary p-3"><span class="spinner-border spinner-border-sm me-2"></span>' + {{ 'decouverte.search.searching'|trans|json_encode|raw }} + '</div>';
     searchBlock.style.display = '';
 
-    fetch('/decouverte/filter?' + params.toString(), { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/filter?' + params.toString(), { credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         searchGrid.innerHTML = (d.results || []).map(renderCardHTML).join('')
@@ -2057,7 +2058,7 @@
   }
   window._prismarrWatchlistSync = syncAllWlStars;
 
-  fetch('/decouverte/watchlist/status', { credentials: 'same-origin' })
+  fetch(BASE + '/decouverte/watchlist/status', { credentials: 'same-origin' })
     .then(function(r) { return r.json(); })
     .then(function(d) {
       window._prismarrWatchlist = d.index || {};
@@ -2090,7 +2091,7 @@
     else delete window._prismarrWatchlist[key];
     syncWlUI(tmdbId, type, willAdd);
 
-    fetch('/decouverte/watchlist/toggle', {
+    fetch(BASE + '/decouverte/watchlist/toggle', {
       method: 'POST',
       credentials: 'same-origin',
       headers: { 'Content-Type': 'application/json' },

--- a/symfony/templates/decouverte/index.html.twig
+++ b/symfony/templates/decouverte/index.html.twig
@@ -991,7 +991,8 @@
           {% set statusColors = {'downloaded':'#22c55e','missing':'#f59e0b','announced':'#6366f1','inCinemas':'#6366f1','partial':'#3b82f6','unmonitored':'#6b7280'} %}
           {% set statusKey = 'decouverte.modal.status.' ~ (item.lib_status ?: 'downloaded') %}
           {% set statusLabel = item.lib_status ? statusKey|trans : 'decouverte.card.in_library_short'|trans %}
-          <a href="{{ (item.type == 'movie' ? '/medias/' ~ current_slug('radarr') ~ '/films' : '/medias/' ~ current_slug('sonarr') ~ '/series') ~ '?open=' ~ item.lib_id }}" class="btn btn-sm" style="background:{{ statusColors[item.lib_status] ?? '#22c55e' }};color:#fff;">{{ statusLabel }}</a>
+          {% set basePath = app.request.getBasePath() %}
+          <a href="{{ (item.type == 'movie' ? basePath ~ '/medias/' ~ current_slug('radarr') ~ '/films' : basePath ~ '/medias/' ~ current_slug('sonarr') ~ '/series') ~ '?open=' ~ item.lib_id }}" class="btn btn-sm" style="background:{{ statusColors[item.lib_status] ?? '#22c55e' }};color:#fff;">{{ statusLabel }}</a>
         {% endif %}
       </div>
     </div>
@@ -1000,6 +1001,7 @@
 
 <script>
 (function() {
+  var BASE = window.BASE_PATH;
   function escHtml(s) { var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
 
   // Localized strings used by the detail modal + toasts. Built server-side
@@ -1185,7 +1187,7 @@
     btn.disabled = true;
     btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
 
-    fetch('/decouverte/resolve/' + type + '/' + id, { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/resolve/' + type + '/' + id, { credentials: 'same-origin' })
       .then(function(r) { return r.json().then(function(d) { return { ok: r.ok, body: d }; }); })
       .then(function(res) {
         btn.disabled = false;
@@ -1374,7 +1376,7 @@
       actions.push('<button class="btn btn-primary tmdb-add-btn" data-tmdb-id="' + d.id + '" data-tmdb-type="' + d.type + '" data-tmdb-title="' + safeTitle + '">'
         + '<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="me-1"><path d="M12 5v14"/><path d="M5 12h14"/></svg>' + (d.type === 'movie' ? TMDB_I18N.add_to_radarr : TMDB_I18N.add_to_sonarr) + '</button>');
     } else {
-      var libUrl = d.type === 'movie' ? '/medias/' + DEFAULT_RADARR_SLUG + '/films' : '/medias/' + DEFAULT_SONARR_SLUG + '/series';
+      var libUrl = d.type === 'movie' ? BASE + '/medias/' + DEFAULT_RADARR_SLUG + '/films' : BASE + '/medias/' + DEFAULT_SONARR_SLUG + '/series';
       if (d.lib_id) libUrl += '?open=' + d.lib_id;
       var btnClass = d.lib_status === 'downloaded' ? 'btn-success' : (d.lib_status === 'missing' || d.lib_status === 'partial' ? 'btn-warning' : 'btn-outline-primary');
       actions.push('<a href="' + libUrl + '" class="btn ' + btnClass + '">'
@@ -1759,7 +1761,7 @@
     var libBadge = item.in_library ? '<span class="lib-badge" style="background:' + (statusColors[item.lib_status] || '#22c55e') + ';">' + (cardShort[item.lib_status] || cardShort._default) + '</span>' : '';
     var voteBadge = item.vote ? '<span class="vote-badge ' + vc + '">' + {{ ico.icon('star-filled', '', 12)|json_encode|raw }} + ' ' + item.vote + '</span>' : '';
     var hoverBtn  = item.in_library
-      ? '<a href="' + (item.type === 'movie' ? '/medias/' + DEFAULT_RADARR_SLUG + '/films' : '/medias/' + DEFAULT_SONARR_SLUG + '/series') + '?open=' + (item.lib_id||'') + '" class="btn btn-sm" style="background:' + ({downloaded:'#22c55e',missing:'#f59e0b',announced:'#6366f1',inCinemas:'#6366f1',partial:'#3b82f6',unmonitored:'#6b7280'}[item.lib_status]||'#22c55e') + ';color:#fff;">' + (cardShort[item.lib_status] || inLibraryShort) + '</a>'
+      ? '<a href="' + (item.type === 'movie' ? BASE + '/medias/' + DEFAULT_RADARR_SLUG + '/films' : BASE + '/medias/' + DEFAULT_SONARR_SLUG + '/series') + '?open=' + (item.lib_id||'') + '" class="btn btn-sm" style="background:' + ({downloaded:'#22c55e',missing:'#f59e0b',announced:'#6366f1',inCinemas:'#6366f1',partial:'#3b82f6',unmonitored:'#6b7280'}[item.lib_status]||'#22c55e') + ';color:#fff;">' + (cardShort[item.lib_status] || inLibraryShort) + '</a>'
       : '<button type="button" class="btn btn-primary btn-sm tmdb-add-btn" data-tmdb-id="' + item.id + '" data-tmdb-type="' + item.type + '" data-tmdb-title="' + safeTitle + '">' + {{ 'decouverte.action.add'|trans|json_encode|raw }} + '</button>';
 
     var wlClass = (window._prismarrWatchlist && window._prismarrWatchlist[item.type + '_' + item.id]) ? ' in-wl' : '';
@@ -1791,7 +1793,7 @@
 
   function loadDetail(type, id) {
     openDetailModal();
-    fetch('/decouverte/detail/' + type + '/' + id, { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/detail/' + type + '/' + id, { credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         if (d.error) {
@@ -1831,7 +1833,7 @@
       return;
     }
     searchAbort = new AbortController();
-    fetch('/decouverte/search?q=' + encodeURIComponent(q), { signal: searchAbort.signal, credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/search?q=' + encodeURIComponent(q), { signal: searchAbort.signal, credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         var results = d.results || [];
@@ -1890,7 +1892,7 @@
   // ── Recommendations based on the library (AJAX load on page load)
   var myRecsBlock = document.getElementById('tmdb-my-recs');
   var myRecsRow = document.getElementById('tmdb-my-recs-row');
-  fetch('/decouverte/mes-recommandations', { credentials: 'same-origin' })
+  fetch(BASE + '/decouverte/mes-recommandations', { credentials: 'same-origin' })
     .then(function(r) { return r.json(); })
     .then(function(d) {
       if (d.seeds === 0 || !d.results || !d.results.length) {
@@ -1932,7 +1934,7 @@
   }
 
   function loadGenres(type) {
-    fetch('/decouverte/genres/' + type, { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/genres/' + type, { credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         genresCache[type] = d.genres || [];
@@ -2005,7 +2007,7 @@
     searchGrid.innerHTML = '<div class="text-secondary p-3"><span class="spinner-border spinner-border-sm me-2"></span>' + {{ 'decouverte.search.searching'|trans|json_encode|raw }} + '</div>';
     searchBlock.style.display = '';
 
-    fetch('/decouverte/filter?' + params.toString(), { credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/filter?' + params.toString(), { credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         searchGrid.innerHTML = (d.results || []).map(renderCardHTML).join('')
@@ -2057,7 +2059,7 @@
   }
   window._prismarrWatchlistSync = syncAllWlStars;
 
-  fetch('/decouverte/watchlist/status', { credentials: 'same-origin' })
+  fetch(BASE + '/decouverte/watchlist/status', { credentials: 'same-origin' })
     .then(function(r) { return r.json(); })
     .then(function(d) {
       window._prismarrWatchlist = d.index || {};
@@ -2090,7 +2092,7 @@
     else delete window._prismarrWatchlist[key];
     syncWlUI(tmdbId, type, willAdd);
 
-    fetch('/decouverte/watchlist/toggle', {
+    fetch(BASE + '/decouverte/watchlist/toggle', {
       method: 'POST',
       credentials: 'same-origin',
       headers: { 'Content-Type': 'application/json' },

--- a/symfony/templates/decouverte/watchlist.html.twig
+++ b/symfony/templates/decouverte/watchlist.html.twig
@@ -232,6 +232,7 @@
 
 <script>
 (function() {
+  var BASE = '{{ app.request.getBasePath() }}';
   var grid = document.getElementById('wl-grid');
   var cards = grid ? Array.from(grid.querySelectorAll('.wl-card')) : [];
   var currentFilter = 'all';
@@ -304,7 +305,7 @@
     var wlId = rmBtn.dataset.wlId;
     if (!confirm({{ 'decouverte.watchlist.remove_confirm'|trans({title: '__TITLE__'})|json_encode|raw }}.replace('__TITLE__', card.dataset.title))) return;
 
-    fetch('/decouverte/watchlist/remove/' + wlId, { method: 'POST', credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/watchlist/remove/' + wlId, { method: 'POST', credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         if (d.ok) {
@@ -364,7 +365,7 @@
   notesSave.addEventListener('click', function() {
     if (!currentNotesId) return;
     var notes = notesText.value.trim();
-    fetch('/decouverte/watchlist/notes/' + currentNotesId, {
+    fetch(BASE + '/decouverte/watchlist/notes/' + currentNotesId, {
       method: 'POST',
       credentials: 'same-origin',
       headers: { 'Content-Type': 'application/json' },
@@ -396,7 +397,7 @@
     if (e.target.closest('.wl-remove') || e.target.closest('.wl-notes-ico')) return;
     var card = e.target.closest('.wl-card');
     if (!card) return;
-    window.location.href = '/decouverte?detail=' + card.dataset.type + '/' + card.dataset.tmdbId;
+    window.location.href = BASE + '/decouverte?detail=' + card.dataset.type + '/' + card.dataset.tmdbId;
   });
 
   function updateStats() {

--- a/symfony/templates/decouverte/watchlist.html.twig
+++ b/symfony/templates/decouverte/watchlist.html.twig
@@ -232,6 +232,7 @@
 
 <script>
 (function() {
+  var BASE = window.BASE_PATH;
   var grid = document.getElementById('wl-grid');
   var cards = grid ? Array.from(grid.querySelectorAll('.wl-card')) : [];
   var currentFilter = 'all';
@@ -304,7 +305,7 @@
     var wlId = rmBtn.dataset.wlId;
     if (!confirm({{ 'decouverte.watchlist.remove_confirm'|trans({title: '__TITLE__'})|json_encode|raw }}.replace('__TITLE__', card.dataset.title))) return;
 
-    fetch('/decouverte/watchlist/remove/' + wlId, { method: 'POST', credentials: 'same-origin' })
+    fetch(BASE + '/decouverte/watchlist/remove/' + wlId, { method: 'POST', credentials: 'same-origin' })
       .then(function(r) { return r.json(); })
       .then(function(d) {
         if (d.ok) {
@@ -364,7 +365,7 @@
   notesSave.addEventListener('click', function() {
     if (!currentNotesId) return;
     var notes = notesText.value.trim();
-    fetch('/decouverte/watchlist/notes/' + currentNotesId, {
+    fetch(BASE + '/decouverte/watchlist/notes/' + currentNotesId, {
       method: 'POST',
       credentials: 'same-origin',
       headers: { 'Content-Type': 'application/json' },
@@ -396,7 +397,7 @@
     if (e.target.closest('.wl-remove') || e.target.closest('.wl-notes-ico')) return;
     var card = e.target.closest('.wl-card');
     if (!card) return;
-    window.location.href = '/decouverte?detail=' + card.dataset.type + '/' + card.dataset.tmdbId;
+    window.location.href = BASE + '/decouverte?detail=' + card.dataset.type + '/' + card.dataset.tmdbId;
   });
 
   function updateStats() {

--- a/symfony/templates/jellyseerr/index.html.twig
+++ b/symfony/templates/jellyseerr/index.html.twig
@@ -379,6 +379,7 @@
 {% block javascripts %}
 <script>
 (function(){
+    var BASE = '{{ app.request.getBasePath() }}';
     var _I18N = {
         movie: {{ 'jellyseerr.common.movie'|trans|json_encode|raw }},
         tv: {{ 'jellyseerr.common.tv'|trans|json_encode|raw }},
@@ -481,7 +482,7 @@
             this.disabled = true;
             var self = this;
 
-            fetch('/jellyseerr/request/' + id + '/' + action, {
+            fetch(BASE + '/jellyseerr/request/' + id + '/' + action, {
                 method: 'POST',
                 credentials: 'same-origin',
                 headers: {'X-Requested-With': 'XMLHttpRequest'}
@@ -525,7 +526,7 @@
         var body = document.getElementById('js-modal-body');
         body.innerHTML = '<div class="text-center py-5"><div class="spinner-border text-purple"></div></div>';
 
-        fetch('/jellyseerr/request/' + id, { credentials: 'same-origin', headers: {'Accept':'application/json'} })
+        fetch(BASE + '/jellyseerr/request/' + id, { credentials: 'same-origin', headers: {'Accept':'application/json'} })
             .then(function(r){ return r.json(); })
             .then(function(req){
                 currentReq = req;
@@ -666,7 +667,7 @@
                         if (act === 'delete' && !confirm(_I18N.confirmDelete)) return;
                         this.disabled = true;
 
-                        fetch('/jellyseerr/request/' + rid + '/' + act, { method:'POST', credentials:'same-origin', headers:{'X-Requested-With':'XMLHttpRequest'} })
+                        fetch(BASE + '/jellyseerr/request/' + rid + '/' + act, { method:'POST', credentials:'same-origin', headers:{'X-Requested-With':'XMLHttpRequest'} })
                             .then(function(r){ return r.json(); })
                             .then(function(d){
                                 if (d.ok) {
@@ -699,15 +700,15 @@
         // Load request if not cached
         var reqPromise = (currentReq && String(currentReq.id) === String(id))
             ? Promise.resolve(currentReq)
-            : fetch('/jellyseerr/request/' + id, { credentials:'same-origin', headers:{'Accept':'application/json'} }).then(function(r){ return r.json(); });
+            : fetch(BASE + '/jellyseerr/request/' + id, { credentials:'same-origin', headers:{'Accept':'application/json'} }).then(function(r){ return r.json(); });
 
         reqPromise.then(function(req){
             var tmdb = req._tmdb || {};
             var serviceType = req.type === 'movie' ? 'radarr' : 'sonarr';
             titleEl.textContent = tpl(_I18N.editRequestTitleTpl, {TITLE: tmdb.title || tpl(_I18N.editRequestFallbackTpl, {ID: req.id})});
 
-            var svcP = fetch('/jellyseerr/service/' + serviceType, { credentials:'same-origin', headers:{'Accept':'application/json'} }).then(function(r){ return r.json(); }).catch(function(){ return {}; });
-            var usersP = fetch('/jellyseerr/users', { credentials:'same-origin', headers:{'Accept':'application/json'} }).then(function(r){ return r.json(); }).catch(function(){ return []; });
+            var svcP = fetch(BASE + '/jellyseerr/service/' + serviceType, { credentials:'same-origin', headers:{'Accept':'application/json'} }).then(function(r){ return r.json(); }).catch(function(){ return {}; });
+            var usersP = fetch(BASE + '/jellyseerr/users', { credentials:'same-origin', headers:{'Accept':'application/json'} }).then(function(r){ return r.json(); }).catch(function(){ return []; });
 
             Promise.all([svcP, usersP]).then(function(results){
                 var svc = results[0];
@@ -855,7 +856,7 @@
                     saveBtn.disabled = true;
                     saveBtn.innerHTML = '<div class="spinner-border spinner-border-sm" style="width:16px;height:16px;"></div> ' + _I18N.savingShort;
 
-                    fetch('/jellyseerr/request/' + req.id + '/edit', {
+                    fetch(BASE + '/jellyseerr/request/' + req.id + '/edit', {
                         method: 'POST',
                         credentials: 'same-origin',
                         headers: {'Content-Type':'application/json', 'X-Requested-With':'XMLHttpRequest'},

--- a/symfony/templates/jellyseerr/index.html.twig
+++ b/symfony/templates/jellyseerr/index.html.twig
@@ -379,6 +379,7 @@
 {% block javascripts %}
 <script>
 (function(){
+    var BASE = window.BASE_PATH;
     var _I18N = {
         movie: {{ 'jellyseerr.common.movie'|trans|json_encode|raw }},
         tv: {{ 'jellyseerr.common.tv'|trans|json_encode|raw }},
@@ -481,7 +482,7 @@
             this.disabled = true;
             var self = this;
 
-            fetch('/jellyseerr/request/' + id + '/' + action, {
+            fetch(BASE + '/jellyseerr/request/' + id + '/' + action, {
                 method: 'POST',
                 credentials: 'same-origin',
                 headers: {'X-Requested-With': 'XMLHttpRequest'}
@@ -525,7 +526,7 @@
         var body = document.getElementById('js-modal-body');
         body.innerHTML = '<div class="text-center py-5"><div class="spinner-border text-purple"></div></div>';
 
-        fetch('/jellyseerr/request/' + id, { credentials: 'same-origin', headers: {'Accept':'application/json'} })
+        fetch(BASE + '/jellyseerr/request/' + id, { credentials: 'same-origin', headers: {'Accept':'application/json'} })
             .then(function(r){ return r.json(); })
             .then(function(req){
                 currentReq = req;
@@ -666,7 +667,7 @@
                         if (act === 'delete' && !confirm(_I18N.confirmDelete)) return;
                         this.disabled = true;
 
-                        fetch('/jellyseerr/request/' + rid + '/' + act, { method:'POST', credentials:'same-origin', headers:{'X-Requested-With':'XMLHttpRequest'} })
+                        fetch(BASE + '/jellyseerr/request/' + rid + '/' + act, { method:'POST', credentials:'same-origin', headers:{'X-Requested-With':'XMLHttpRequest'} })
                             .then(function(r){ return r.json(); })
                             .then(function(d){
                                 if (d.ok) {
@@ -699,15 +700,15 @@
         // Load request if not cached
         var reqPromise = (currentReq && String(currentReq.id) === String(id))
             ? Promise.resolve(currentReq)
-            : fetch('/jellyseerr/request/' + id, { credentials:'same-origin', headers:{'Accept':'application/json'} }).then(function(r){ return r.json(); });
+            : fetch(BASE + '/jellyseerr/request/' + id, { credentials:'same-origin', headers:{'Accept':'application/json'} }).then(function(r){ return r.json(); });
 
         reqPromise.then(function(req){
             var tmdb = req._tmdb || {};
             var serviceType = req.type === 'movie' ? 'radarr' : 'sonarr';
             titleEl.textContent = tpl(_I18N.editRequestTitleTpl, {TITLE: tmdb.title || tpl(_I18N.editRequestFallbackTpl, {ID: req.id})});
 
-            var svcP = fetch('/jellyseerr/service/' + serviceType, { credentials:'same-origin', headers:{'Accept':'application/json'} }).then(function(r){ return r.json(); }).catch(function(){ return {}; });
-            var usersP = fetch('/jellyseerr/users', { credentials:'same-origin', headers:{'Accept':'application/json'} }).then(function(r){ return r.json(); }).catch(function(){ return []; });
+            var svcP = fetch(BASE + '/jellyseerr/service/' + serviceType, { credentials:'same-origin', headers:{'Accept':'application/json'} }).then(function(r){ return r.json(); }).catch(function(){ return {}; });
+            var usersP = fetch(BASE + '/jellyseerr/users', { credentials:'same-origin', headers:{'Accept':'application/json'} }).then(function(r){ return r.json(); }).catch(function(){ return []; });
 
             Promise.all([svcP, usersP]).then(function(results){
                 var svc = results[0];
@@ -855,7 +856,7 @@
                     saveBtn.disabled = true;
                     saveBtn.innerHTML = '<div class="spinner-border spinner-border-sm" style="width:16px;height:16px;"></div> ' + _I18N.savingShort;
 
-                    fetch('/jellyseerr/request/' + req.id + '/edit', {
+                    fetch(BASE + '/jellyseerr/request/' + req.id + '/edit', {
                         method: 'POST',
                         credentials: 'same-origin',
                         headers: {'Content-Type':'application/json', 'X-Requested-With':'XMLHttpRequest'},

--- a/symfony/templates/jellyseerr/settings/general.html.twig
+++ b/symfony/templates/jellyseerr/settings/general.html.twig
@@ -175,6 +175,7 @@
 {% block javascripts %}
 <script>
 (function(){
+    var BASE = '{{ app.request.getBasePath() }}';
     var _I18N = {
         allLanguages: {{ 'jellyseerr.settings.general.all_languages'|trans|json_encode|raw }},
         languagesCountOne: {{ 'jellyseerr.user_detail.languages_count_one'|trans|json_encode|raw }},
@@ -218,7 +219,7 @@
         var langs = []; document.querySelectorAll('.js-lang-cb:checked').forEach(function(cb){ langs.push(cb.value); }); payload.originalLanguage = langs.join('|');
         if (payload.blacklistedTagsLimit) payload.blacklistedTagsLimit = parseInt(payload.blacklistedTagsLimit)||50;
         saveBtn.disabled = true; var orig = saveBtn.innerHTML; saveBtn.innerHTML = '<div class="spinner-border spinner-border-sm" style="width:16px;height:16px;"></div>';
-        fetch('/jellyseerr/parametres/save', { method:'POST', credentials:'same-origin', headers:{'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'}, body:JSON.stringify(payload) })
+        fetch(BASE + '/jellyseerr/parametres/save', { method:'POST', credentials:'same-origin', headers:{'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'}, body:JSON.stringify(payload) })
         .then(function(r){ return r.json(); }).then(function(d){ saveBtn.disabled=false; saveBtn.innerHTML=orig; statusEl.innerHTML=d.ok?'<span class="text-success">' + _I18N.saved + '</span>':'<span class="text-danger">' + _I18N.error + '</span>'; setTimeout(function(){statusEl.innerHTML='';},3000); })
         .catch(function(){ saveBtn.disabled=false; saveBtn.innerHTML=orig; statusEl.innerHTML='<span class="text-danger">' + _I18N.error + '</span>'; });
     });

--- a/symfony/templates/jellyseerr/settings/general.html.twig
+++ b/symfony/templates/jellyseerr/settings/general.html.twig
@@ -175,6 +175,7 @@
 {% block javascripts %}
 <script>
 (function(){
+    var BASE = window.BASE_PATH;
     var _I18N = {
         allLanguages: {{ 'jellyseerr.settings.general.all_languages'|trans|json_encode|raw }},
         languagesCountOne: {{ 'jellyseerr.user_detail.languages_count_one'|trans|json_encode|raw }},
@@ -218,7 +219,7 @@
         var langs = []; document.querySelectorAll('.js-lang-cb:checked').forEach(function(cb){ langs.push(cb.value); }); payload.originalLanguage = langs.join('|');
         if (payload.blacklistedTagsLimit) payload.blacklistedTagsLimit = parseInt(payload.blacklistedTagsLimit)||50;
         saveBtn.disabled = true; var orig = saveBtn.innerHTML; saveBtn.innerHTML = '<div class="spinner-border spinner-border-sm" style="width:16px;height:16px;"></div>';
-        fetch('/jellyseerr/parametres/save', { method:'POST', credentials:'same-origin', headers:{'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'}, body:JSON.stringify(payload) })
+        fetch(BASE + '/jellyseerr/parametres/save', { method:'POST', credentials:'same-origin', headers:{'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'}, body:JSON.stringify(payload) })
         .then(function(r){ return r.json(); }).then(function(d){ saveBtn.disabled=false; saveBtn.innerHTML=orig; statusEl.innerHTML=d.ok?'<span class="text-success">' + _I18N.saved + '</span>':'<span class="text-danger">' + _I18N.error + '</span>'; setTimeout(function(){statusEl.innerHTML='';},3000); })
         .catch(function(){ saveBtn.disabled=false; saveBtn.innerHTML=orig; statusEl.innerHTML='<span class="text-danger">' + _I18N.error + '</span>'; });
     });

--- a/symfony/templates/jellyseerr/settings/services.html.twig
+++ b/symfony/templates/jellyseerr/settings/services.html.twig
@@ -171,6 +171,7 @@
 {% block javascripts %}
 <script>
 (function(){
+    var BASE = '{{ app.request.getBasePath() }}';
     var _I18N = {
         addTitleTpl: {{ 'jellyseerr.settings.services.modal_add_title_tpl'|trans|json_encode|raw }},
         editTitleTpl: {{ 'jellyseerr.settings.services.modal_edit_title_tpl'|trans|json_encode|raw }},
@@ -391,8 +392,8 @@
 
         btn.disabled = true; btn.innerHTML = '<div class="spinner-border spinner-border-sm" style="width:14px;height:14px;"></div>';
         var saveUrl = currentId === -1
-            ? '/jellyseerr/parametres/services/' + currentType + '/create'
-            : '/jellyseerr/parametres/services/' + currentType + '/' + currentId + '/save';
+            ? BASE + '/jellyseerr/parametres/services/' + currentType + '/create'
+            : BASE + '/jellyseerr/parametres/services/' + currentType + '/' + currentId + '/save';
         fetch(saveUrl, {
             method:'POST', credentials:'same-origin',
             headers:{'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
@@ -407,7 +408,7 @@
     document.getElementById('js-modal-test').addEventListener('click', function(){
         var statusEl = document.getElementById('js-modal-status');
         statusEl.innerHTML = '<div class="spinner-border spinner-border-sm text-success" style="width:14px;height:14px;"></div> ' + _I18N.testingLabel;
-        fetch('/jellyseerr/parametres/services/test', {
+        fetch(BASE + '/jellyseerr/parametres/services/test', {
             method:'POST', credentials:'same-origin',
             headers:{'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
             body: JSON.stringify({ type:currentType, hostname:document.getElementById('js-srv-host').value, port:parseInt(document.getElementById('js-srv-port').value)||0, apiKey:document.getElementById('js-srv-apikey').value, useSsl:document.getElementById('js-srv-ssl').checked, baseUrl:document.getElementById('js-srv-base').value })
@@ -460,7 +461,7 @@
         var typeLabel = currentType === 'radarr' ? _I18N.radarrLabel : _I18N.sonarrLabel;
         if (!confirm(tpl(_I18N.confirmDeleteTpl, {TYPE: typeLabel}))) return;
         this.disabled = true;
-        fetch('/jellyseerr/parametres/services/' + currentType + '/' + currentId + '/delete', {
+        fetch(BASE + '/jellyseerr/parametres/services/' + currentType + '/' + currentId + '/delete', {
             method:'POST', credentials:'same-origin', headers:{'X-Requested-With':'XMLHttpRequest'}
         })
         .then(function(r){ return r.json(); })
@@ -473,7 +474,7 @@
     document.querySelectorAll('.js-test-srv').forEach(function(btn){
         btn.addEventListener('click', function(){
             var self = this; self.disabled = true; self.innerHTML = '<div class="spinner-border spinner-border-sm" style="width:12px;height:12px;"></div>';
-            fetch('/jellyseerr/parametres/services/test', {
+            fetch(BASE + '/jellyseerr/parametres/services/test', {
                 method:'POST', credentials:'same-origin',
                 headers:{'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
                 body: JSON.stringify({ type:this.dataset.type, hostname:this.dataset.hostname, port:parseInt(this.dataset.port), apiKey:(JSON.parse(this.closest('.card-body').querySelector('.js-edit-srv').dataset.srv)||{}).apiKey||'', useSsl:this.dataset.ssl==='1', baseUrl:this.dataset.base||'' })

--- a/symfony/templates/jellyseerr/settings/services.html.twig
+++ b/symfony/templates/jellyseerr/settings/services.html.twig
@@ -171,6 +171,7 @@
 {% block javascripts %}
 <script>
 (function(){
+    var BASE = window.BASE_PATH;
     var _I18N = {
         addTitleTpl: {{ 'jellyseerr.settings.services.modal_add_title_tpl'|trans|json_encode|raw }},
         editTitleTpl: {{ 'jellyseerr.settings.services.modal_edit_title_tpl'|trans|json_encode|raw }},
@@ -391,8 +392,8 @@
 
         btn.disabled = true; btn.innerHTML = '<div class="spinner-border spinner-border-sm" style="width:14px;height:14px;"></div>';
         var saveUrl = currentId === -1
-            ? '/jellyseerr/parametres/services/' + currentType + '/create'
-            : '/jellyseerr/parametres/services/' + currentType + '/' + currentId + '/save';
+            ? BASE + '/jellyseerr/parametres/services/' + currentType + '/create'
+            : BASE + '/jellyseerr/parametres/services/' + currentType + '/' + currentId + '/save';
         fetch(saveUrl, {
             method:'POST', credentials:'same-origin',
             headers:{'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
@@ -407,7 +408,7 @@
     document.getElementById('js-modal-test').addEventListener('click', function(){
         var statusEl = document.getElementById('js-modal-status');
         statusEl.innerHTML = '<div class="spinner-border spinner-border-sm text-success" style="width:14px;height:14px;"></div> ' + _I18N.testingLabel;
-        fetch('/jellyseerr/parametres/services/test', {
+        fetch(BASE + '/jellyseerr/parametres/services/test', {
             method:'POST', credentials:'same-origin',
             headers:{'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
             body: JSON.stringify({ type:currentType, hostname:document.getElementById('js-srv-host').value, port:parseInt(document.getElementById('js-srv-port').value)||0, apiKey:document.getElementById('js-srv-apikey').value, useSsl:document.getElementById('js-srv-ssl').checked, baseUrl:document.getElementById('js-srv-base').value })
@@ -460,7 +461,7 @@
         var typeLabel = currentType === 'radarr' ? _I18N.radarrLabel : _I18N.sonarrLabel;
         if (!confirm(tpl(_I18N.confirmDeleteTpl, {TYPE: typeLabel}))) return;
         this.disabled = true;
-        fetch('/jellyseerr/parametres/services/' + currentType + '/' + currentId + '/delete', {
+        fetch(BASE + '/jellyseerr/parametres/services/' + currentType + '/' + currentId + '/delete', {
             method:'POST', credentials:'same-origin', headers:{'X-Requested-With':'XMLHttpRequest'}
         })
         .then(function(r){ return r.json(); })
@@ -473,7 +474,7 @@
     document.querySelectorAll('.js-test-srv').forEach(function(btn){
         btn.addEventListener('click', function(){
             var self = this; self.disabled = true; self.innerHTML = '<div class="spinner-border spinner-border-sm" style="width:12px;height:12px;"></div>';
-            fetch('/jellyseerr/parametres/services/test', {
+            fetch(BASE + '/jellyseerr/parametres/services/test', {
                 method:'POST', credentials:'same-origin',
                 headers:{'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
                 body: JSON.stringify({ type:this.dataset.type, hostname:this.dataset.hostname, port:parseInt(this.dataset.port), apiKey:(JSON.parse(this.closest('.card-body').querySelector('.js-edit-srv').dataset.srv)||{}).apiKey||'', useSsl:this.dataset.ssl==='1', baseUrl:this.dataset.base||'' })

--- a/symfony/templates/jellyseerr/settings/tasks_cache.html.twig
+++ b/symfony/templates/jellyseerr/settings/tasks_cache.html.twig
@@ -282,6 +282,7 @@
 {% block javascripts %}
 <script>
 (function(){
+    var BASE = '{{ app.request.getBasePath() }}';
     // ── Run job ──
     document.querySelectorAll('.js-run-job').forEach(function(btn){
         btn.addEventListener('click', function(){
@@ -293,7 +294,7 @@
             var cancelBtn = btn.parentElement.querySelector('.js-cancel-job');
             if (cancelBtn) { cancelBtn.disabled = false; cancelBtn.style.opacity = '1'; }
 
-            fetch('/jellyseerr/job/' + jobId + '/run', {
+            fetch(BASE + '/jellyseerr/job/' + jobId + '/run', {
                 method: 'POST', credentials: 'same-origin',
                 headers: {'X-Requested-With': 'XMLHttpRequest'}
             })
@@ -318,7 +319,7 @@
     document.querySelectorAll('.js-cancel-job').forEach(function(btn){
         btn.addEventListener('click', function(){
             var jobId = btn.dataset.jobId;
-            fetch('/jellyseerr/job/' + jobId + '/cancel', {
+            fetch(BASE + '/jellyseerr/job/' + jobId + '/cancel', {
                 method: 'POST', credentials: 'same-origin',
                 headers: {'X-Requested-With': 'XMLHttpRequest'}
             })
@@ -343,7 +344,7 @@
             btn.disabled = true;
             btn.innerHTML = '<div class="spinner-border spinner-border-sm" style="width:12px;height:12px;"></div>';
 
-            fetch('/jellyseerr/cache/' + cacheId + '/flush', {
+            fetch(BASE + '/jellyseerr/cache/' + cacheId + '/flush', {
                 method: 'POST', credentials: 'same-origin',
                 headers: {'X-Requested-With': 'XMLHttpRequest'}
             })
@@ -370,7 +371,7 @@
         if (!confirm('Vider tout le cache Seerr ?')) return;
         flushAll.disabled = true;
         flushAll.innerHTML = '<div class="spinner-border spinner-border-sm" style="width:14px;height:14px;"></div> Vidage…';
-        fetch('/jellyseerr/cache/flush', {
+        fetch(BASE + '/jellyseerr/cache/flush', {
             method: 'POST', credentials: 'same-origin',
             headers: {'X-Requested-With': 'XMLHttpRequest'}
         })
@@ -521,7 +522,7 @@
         if (!schedule || schedule === '—') return;
 
         cronSave.disabled = true;
-        fetch('/jellyseerr/job/' + jobId + '/schedule', {
+        fetch(BASE + '/jellyseerr/job/' + jobId + '/schedule', {
             method: 'POST', credentials: 'same-origin',
             headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
             body: JSON.stringify({schedule: schedule})

--- a/symfony/templates/jellyseerr/settings/tasks_cache.html.twig
+++ b/symfony/templates/jellyseerr/settings/tasks_cache.html.twig
@@ -282,6 +282,7 @@
 {% block javascripts %}
 <script>
 (function(){
+    var BASE = window.BASE_PATH;
     // ── Run job ──
     document.querySelectorAll('.js-run-job').forEach(function(btn){
         btn.addEventListener('click', function(){
@@ -293,7 +294,7 @@
             var cancelBtn = btn.parentElement.querySelector('.js-cancel-job');
             if (cancelBtn) { cancelBtn.disabled = false; cancelBtn.style.opacity = '1'; }
 
-            fetch('/jellyseerr/job/' + jobId + '/run', {
+            fetch(BASE + '/jellyseerr/job/' + jobId + '/run', {
                 method: 'POST', credentials: 'same-origin',
                 headers: {'X-Requested-With': 'XMLHttpRequest'}
             })
@@ -318,7 +319,7 @@
     document.querySelectorAll('.js-cancel-job').forEach(function(btn){
         btn.addEventListener('click', function(){
             var jobId = btn.dataset.jobId;
-            fetch('/jellyseerr/job/' + jobId + '/cancel', {
+            fetch(BASE + '/jellyseerr/job/' + jobId + '/cancel', {
                 method: 'POST', credentials: 'same-origin',
                 headers: {'X-Requested-With': 'XMLHttpRequest'}
             })
@@ -343,7 +344,7 @@
             btn.disabled = true;
             btn.innerHTML = '<div class="spinner-border spinner-border-sm" style="width:12px;height:12px;"></div>';
 
-            fetch('/jellyseerr/cache/' + cacheId + '/flush', {
+            fetch(BASE + '/jellyseerr/cache/' + cacheId + '/flush', {
                 method: 'POST', credentials: 'same-origin',
                 headers: {'X-Requested-With': 'XMLHttpRequest'}
             })
@@ -370,7 +371,7 @@
         if (!confirm('Vider tout le cache Seerr ?')) return;
         flushAll.disabled = true;
         flushAll.innerHTML = '<div class="spinner-border spinner-border-sm" style="width:14px;height:14px;"></div> Vidage…';
-        fetch('/jellyseerr/cache/flush', {
+        fetch(BASE + '/jellyseerr/cache/flush', {
             method: 'POST', credentials: 'same-origin',
             headers: {'X-Requested-With': 'XMLHttpRequest'}
         })
@@ -521,7 +522,7 @@
         if (!schedule || schedule === '—') return;
 
         cronSave.disabled = true;
-        fetch('/jellyseerr/job/' + jobId + '/schedule', {
+        fetch(BASE + '/jellyseerr/job/' + jobId + '/schedule', {
             method: 'POST', credentials: 'same-origin',
             headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
             body: JSON.stringify({schedule: schedule})

--- a/symfony/templates/jellyseerr/settings/users.html.twig
+++ b/symfony/templates/jellyseerr/settings/users.html.twig
@@ -150,6 +150,7 @@
 {% block javascripts %}
 <script>
 (function(){
+    var BASE = '{{ app.request.getBasePath() }}';
     var SU_I18N = {
         saved: {{ 'jellyseerr.settings.settings_users.saved'|trans|json_encode|raw }},
         error: {{ 'jellyseerr.settings.settings_users.error'|trans|json_encode|raw }}
@@ -207,7 +208,7 @@
 
         saveBtn.disabled = true; var orig = saveBtn.innerHTML;
         saveBtn.innerHTML = '<div class="spinner-border spinner-border-sm" style="width:16px;height:16px;"></div>';
-        fetch('/jellyseerr/parametres/save', { method:'POST', credentials:'same-origin', headers:{'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'}, body:JSON.stringify(payload) })
+        fetch(BASE + '/jellyseerr/parametres/save', { method:'POST', credentials:'same-origin', headers:{'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'}, body:JSON.stringify(payload) })
         .then(function(r){ return r.json(); })
         .then(function(d){ saveBtn.disabled=false; saveBtn.innerHTML=orig; statusEl.innerHTML=d.ok?'<span class="text-success">'+SU_I18N.saved+'</span>':'<span class="text-danger">'+SU_I18N.error+'</span>'; setTimeout(function(){statusEl.innerHTML='';},3000); })
         .catch(function(){ saveBtn.disabled=false; saveBtn.innerHTML=orig; statusEl.innerHTML='<span class="text-danger">'+SU_I18N.error+'</span>'; });

--- a/symfony/templates/jellyseerr/settings/users.html.twig
+++ b/symfony/templates/jellyseerr/settings/users.html.twig
@@ -150,6 +150,7 @@
 {% block javascripts %}
 <script>
 (function(){
+    var BASE = window.BASE_PATH;
     var SU_I18N = {
         saved: {{ 'jellyseerr.settings.settings_users.saved'|trans|json_encode|raw }},
         error: {{ 'jellyseerr.settings.settings_users.error'|trans|json_encode|raw }}
@@ -207,7 +208,7 @@
 
         saveBtn.disabled = true; var orig = saveBtn.innerHTML;
         saveBtn.innerHTML = '<div class="spinner-border spinner-border-sm" style="width:16px;height:16px;"></div>';
-        fetch('/jellyseerr/parametres/save', { method:'POST', credentials:'same-origin', headers:{'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'}, body:JSON.stringify(payload) })
+        fetch(BASE + '/jellyseerr/parametres/save', { method:'POST', credentials:'same-origin', headers:{'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'}, body:JSON.stringify(payload) })
         .then(function(r){ return r.json(); })
         .then(function(d){ saveBtn.disabled=false; saveBtn.innerHTML=orig; statusEl.innerHTML=d.ok?'<span class="text-success">'+SU_I18N.saved+'</span>':'<span class="text-danger">'+SU_I18N.error+'</span>'; setTimeout(function(){statusEl.innerHTML='';},3000); })
         .catch(function(){ saveBtn.disabled=false; saveBtn.innerHTML=orig; statusEl.innerHTML='<span class="text-danger">'+SU_I18N.error+'</span>'; });

--- a/symfony/templates/jellyseerr/user_detail.html.twig
+++ b/symfony/templates/jellyseerr/user_detail.html.twig
@@ -523,6 +523,7 @@
 {% block javascripts %}
 <script>
 (function(){
+    var BASE = '{{ app.request.getBasePath() }}';
     var _I18N = {
         saved: {{ 'jellyseerr.common.saved'|trans|json_encode|raw }},
         error: {{ 'jellyseerr.common.error'|trans|json_encode|raw }},
@@ -645,7 +646,7 @@
         var discoverLangs = [];
         document.querySelectorAll('.js-lang-cb:checked').forEach(function(cb){ discoverLangs.push(cb.value); });
         var discoverLangVal = discoverLangs.join('|');
-        postJSON('/jellyseerr/utilisateurs/' + userId + '/settings', {
+        postJSON(BASE + '/jellyseerr/utilisateurs/' + userId + '/settings', {
             username: document.getElementById('js-set-username').value.trim() || null,
             email: document.getElementById('js-set-email').value.trim(),
             locale: langVal === '' ? '' : langVal,
@@ -668,7 +669,7 @@
         var statusEl = document.getElementById('js-password-status');
         if (pw.length < 8) { feedback(statusEl, false, _I18N.passwordMinLength); return; }
         if (pw !== confirm) { feedback(statusEl, false, _I18N.passwordMismatch); return; }
-        postJSON('/jellyseerr/utilisateurs/' + userId + '/password', {password: pw}, this, statusEl);
+        postJSON(BASE + '/jellyseerr/utilisateurs/' + userId + '/password', {password: pw}, this, statusEl);
     });
 
     // ── Permissions — same behavior as native Seerr ──
@@ -767,7 +768,7 @@
         fourKBits.forEach(function(bit) {
             if (originalPerms & bit) newPerms |= bit;
         });
-        postJSON('/jellyseerr/utilisateurs/' + userId + '/permissions', {permissions: newPerms}, this, document.getElementById('js-perms-status'));
+        postJSON(BASE + '/jellyseerr/utilisateurs/' + userId + '/permissions', {permissions: newPerms}, this, document.getElementById('js-perms-status'));
     });
 
     // ── Notification channel tabs ──
@@ -855,7 +856,7 @@
         el = document.getElementById('js-notif-pushover-user');
         if (el) payload.pushoverUserKey = el.value.trim() || null;
 
-        postJSON('/jellyseerr/utilisateurs/' + userId + '/notifications', payload, this, document.getElementById('js-notifs-status'));
+        postJSON(BASE + '/jellyseerr/utilisateurs/' + userId + '/notifications', payload, this, document.getElementById('js-notifs-status'));
     });
 
     // ── Delete user ──
@@ -863,12 +864,12 @@
     if (deleteBtn) deleteBtn.addEventListener('click', function(){
         if (!confirm(_I18N.confirmDelete)) return;
         this.disabled = true;
-        fetch('/jellyseerr/utilisateurs/' + userId + '/delete', {
+        fetch(BASE + '/jellyseerr/utilisateurs/' + userId + '/delete', {
             method:'POST', credentials:'same-origin', headers:{'X-Requested-With':'XMLHttpRequest'}
         })
         .then(function(r){ return r.json(); })
         .then(function(d){
-            if (d.ok) { window.location.href = '/jellyseerr/utilisateurs'; }
+            if (d.ok) { window.location.href = BASE + '/jellyseerr/utilisateurs'; }
             else { alert(d.error || _I18N.error); deleteBtn.disabled = false; }
         });
     });

--- a/symfony/templates/jellyseerr/user_detail.html.twig
+++ b/symfony/templates/jellyseerr/user_detail.html.twig
@@ -523,6 +523,7 @@
 {% block javascripts %}
 <script>
 (function(){
+    var BASE = window.BASE_PATH;
     var _I18N = {
         saved: {{ 'jellyseerr.common.saved'|trans|json_encode|raw }},
         error: {{ 'jellyseerr.common.error'|trans|json_encode|raw }},
@@ -645,7 +646,7 @@
         var discoverLangs = [];
         document.querySelectorAll('.js-lang-cb:checked').forEach(function(cb){ discoverLangs.push(cb.value); });
         var discoverLangVal = discoverLangs.join('|');
-        postJSON('/jellyseerr/utilisateurs/' + userId + '/settings', {
+        postJSON(BASE + '/jellyseerr/utilisateurs/' + userId + '/settings', {
             username: document.getElementById('js-set-username').value.trim() || null,
             email: document.getElementById('js-set-email').value.trim(),
             locale: langVal === '' ? '' : langVal,
@@ -668,7 +669,7 @@
         var statusEl = document.getElementById('js-password-status');
         if (pw.length < 8) { feedback(statusEl, false, _I18N.passwordMinLength); return; }
         if (pw !== confirm) { feedback(statusEl, false, _I18N.passwordMismatch); return; }
-        postJSON('/jellyseerr/utilisateurs/' + userId + '/password', {password: pw}, this, statusEl);
+        postJSON(BASE + '/jellyseerr/utilisateurs/' + userId + '/password', {password: pw}, this, statusEl);
     });
 
     // ── Permissions — same behavior as native Seerr ──
@@ -767,7 +768,7 @@
         fourKBits.forEach(function(bit) {
             if (originalPerms & bit) newPerms |= bit;
         });
-        postJSON('/jellyseerr/utilisateurs/' + userId + '/permissions', {permissions: newPerms}, this, document.getElementById('js-perms-status'));
+        postJSON(BASE + '/jellyseerr/utilisateurs/' + userId + '/permissions', {permissions: newPerms}, this, document.getElementById('js-perms-status'));
     });
 
     // ── Notification channel tabs ──
@@ -855,7 +856,7 @@
         el = document.getElementById('js-notif-pushover-user');
         if (el) payload.pushoverUserKey = el.value.trim() || null;
 
-        postJSON('/jellyseerr/utilisateurs/' + userId + '/notifications', payload, this, document.getElementById('js-notifs-status'));
+        postJSON(BASE + '/jellyseerr/utilisateurs/' + userId + '/notifications', payload, this, document.getElementById('js-notifs-status'));
     });
 
     // ── Delete user ──
@@ -863,12 +864,12 @@
     if (deleteBtn) deleteBtn.addEventListener('click', function(){
         if (!confirm(_I18N.confirmDelete)) return;
         this.disabled = true;
-        fetch('/jellyseerr/utilisateurs/' + userId + '/delete', {
+        fetch(BASE + '/jellyseerr/utilisateurs/' + userId + '/delete', {
             method:'POST', credentials:'same-origin', headers:{'X-Requested-With':'XMLHttpRequest'}
         })
         .then(function(r){ return r.json(); })
         .then(function(d){
-            if (d.ok) { window.location.href = '/jellyseerr/utilisateurs'; }
+            if (d.ok) { window.location.href = BASE + '/jellyseerr/utilisateurs'; }
             else { alert(d.error || _I18N.error); deleteBtn.disabled = false; }
         });
     });

--- a/symfony/templates/jellyseerr/users.html.twig
+++ b/symfony/templates/jellyseerr/users.html.twig
@@ -194,6 +194,7 @@
 {% block javascripts %}
 <script>
 (function(){
+    var BASE = '{{ app.request.getBasePath() }}';
     var _I18N = {
         confirmDeleteTpl: {{ 'jellyseerr.common.confirm_delete_user_tpl'|trans|json_encode|raw }},
         cannotDelete: {{ 'jellyseerr.users.cannot_delete_account'|trans|json_encode|raw }},
@@ -307,7 +308,7 @@
 
             var self = this;
             self.disabled = true;
-            fetch('/jellyseerr/utilisateurs/' + id + '/delete', {
+            fetch(BASE + '/jellyseerr/utilisateurs/' + id + '/delete', {
                 method:'POST', credentials:'same-origin', headers:{'X-Requested-With':'XMLHttpRequest'}
             })
             .then(function(r){ return r.json(); })
@@ -336,7 +337,7 @@
         var body = document.getElementById('js-create-body');
         body.innerHTML = '<div class="text-center py-3"><div class="spinner-border text-purple"></div></div>';
 
-        fetch('/jellyseerr/service/settings-main', { credentials:'same-origin', headers:{'Accept':'application/json'} })
+        fetch(BASE + '/jellyseerr/service/settings-main', { credentials:'same-origin', headers:{'Accept':'application/json'} })
             .then(function(r){ return r.json(); })
             .then(function(settings){
                 var localLogin = settings.localLogin || false;
@@ -446,7 +447,7 @@
         createSubmit.disabled = true;
         createSubmit.innerHTML = '<div class="spinner-border spinner-border-sm"></div>';
 
-        fetch('/jellyseerr/utilisateurs/create', {
+        fetch(BASE + '/jellyseerr/utilisateurs/create', {
             method:'POST', credentials:'same-origin',
             headers:{'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
             body: JSON.stringify(payload)
@@ -466,7 +467,7 @@
         body.innerHTML = '<div class="text-center py-3"><div class="spinner-border text-purple"></div></div>';
         submitBtn.disabled = true;
 
-        fetch('/jellyseerr/service/jellyfin-users', { credentials:'same-origin', headers:{'Accept':'application/json'} })
+        fetch(BASE + '/jellyseerr/service/jellyfin-users', { credentials:'same-origin', headers:{'Accept':'application/json'} })
             .then(function(r){ return r.json(); })
             .then(function(data){
                 var users = data.users || [];
@@ -522,7 +523,7 @@
         importSubmit.disabled = true;
         importSubmit.innerHTML = '<div class="spinner-border spinner-border-sm"></div>';
 
-        fetch('/jellyseerr/utilisateurs/import-jellyfin', {
+        fetch(BASE + '/jellyseerr/utilisateurs/import-jellyfin', {
             method:'POST', credentials:'same-origin',
             headers:{'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
             body: JSON.stringify({jellyfinUserIds: ids})
@@ -545,7 +546,7 @@
         var body = document.getElementById('js-profile-body');
         body.innerHTML = '<div class="text-center py-4"><div class="spinner-border text-purple"></div></div>';
 
-        fetch('/jellyseerr/utilisateurs/' + id, { credentials:'same-origin', headers:{'Accept':'application/json','X-Requested-With':'XMLHttpRequest'} })
+        fetch(BASE + '/jellyseerr/utilisateurs/' + id, { credentials:'same-origin', headers:{'Accept':'application/json','X-Requested-With':'XMLHttpRequest'} })
             .then(function(r){ return r.json(); })
             .then(function(u){
                 var name = u.displayName || u.jellyfinUsername || u.email || '?';
@@ -696,7 +697,7 @@
                 if (u.id === 1) {
                     html += '<div class="text-secondary text-center small py-1">' + _I18N.profileOwnerLocked + '</div>';
                 } else {
-                    html += '<a href="/jellyseerr/utilisateurs/' + u.id + '" class="btn btn-primary w-100">';
+                    html += '<a href="' + BASE + '/jellyseerr/utilisateurs/' + u.id + '" class="btn btn-primary w-100">';
                     html += '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="me-1"><path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><circle cx="12" cy="12" r="3"/></svg>';
                     html += _I18N.profileManageUser + '</a>';
                 }

--- a/symfony/templates/jellyseerr/users.html.twig
+++ b/symfony/templates/jellyseerr/users.html.twig
@@ -194,6 +194,7 @@
 {% block javascripts %}
 <script>
 (function(){
+    var BASE = window.BASE_PATH;
     var _I18N = {
         confirmDeleteTpl: {{ 'jellyseerr.common.confirm_delete_user_tpl'|trans|json_encode|raw }},
         cannotDelete: {{ 'jellyseerr.users.cannot_delete_account'|trans|json_encode|raw }},
@@ -307,7 +308,7 @@
 
             var self = this;
             self.disabled = true;
-            fetch('/jellyseerr/utilisateurs/' + id + '/delete', {
+            fetch(BASE + '/jellyseerr/utilisateurs/' + id + '/delete', {
                 method:'POST', credentials:'same-origin', headers:{'X-Requested-With':'XMLHttpRequest'}
             })
             .then(function(r){ return r.json(); })
@@ -336,7 +337,7 @@
         var body = document.getElementById('js-create-body');
         body.innerHTML = '<div class="text-center py-3"><div class="spinner-border text-purple"></div></div>';
 
-        fetch('/jellyseerr/service/settings-main', { credentials:'same-origin', headers:{'Accept':'application/json'} })
+        fetch(BASE + '/jellyseerr/service/settings-main', { credentials:'same-origin', headers:{'Accept':'application/json'} })
             .then(function(r){ return r.json(); })
             .then(function(settings){
                 var localLogin = settings.localLogin || false;
@@ -446,7 +447,7 @@
         createSubmit.disabled = true;
         createSubmit.innerHTML = '<div class="spinner-border spinner-border-sm"></div>';
 
-        fetch('/jellyseerr/utilisateurs/create', {
+        fetch(BASE + '/jellyseerr/utilisateurs/create', {
             method:'POST', credentials:'same-origin',
             headers:{'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
             body: JSON.stringify(payload)
@@ -466,7 +467,7 @@
         body.innerHTML = '<div class="text-center py-3"><div class="spinner-border text-purple"></div></div>';
         submitBtn.disabled = true;
 
-        fetch('/jellyseerr/service/jellyfin-users', { credentials:'same-origin', headers:{'Accept':'application/json'} })
+        fetch(BASE + '/jellyseerr/service/jellyfin-users', { credentials:'same-origin', headers:{'Accept':'application/json'} })
             .then(function(r){ return r.json(); })
             .then(function(data){
                 var users = data.users || [];
@@ -522,7 +523,7 @@
         importSubmit.disabled = true;
         importSubmit.innerHTML = '<div class="spinner-border spinner-border-sm"></div>';
 
-        fetch('/jellyseerr/utilisateurs/import-jellyfin', {
+        fetch(BASE + '/jellyseerr/utilisateurs/import-jellyfin', {
             method:'POST', credentials:'same-origin',
             headers:{'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
             body: JSON.stringify({jellyfinUserIds: ids})
@@ -545,7 +546,7 @@
         var body = document.getElementById('js-profile-body');
         body.innerHTML = '<div class="text-center py-4"><div class="spinner-border text-purple"></div></div>';
 
-        fetch('/jellyseerr/utilisateurs/' + id, { credentials:'same-origin', headers:{'Accept':'application/json','X-Requested-With':'XMLHttpRequest'} })
+        fetch(BASE + '/jellyseerr/utilisateurs/' + id, { credentials:'same-origin', headers:{'Accept':'application/json','X-Requested-With':'XMLHttpRequest'} })
             .then(function(r){ return r.json(); })
             .then(function(u){
                 var name = u.displayName || u.jellyfinUsername || u.email || '?';
@@ -696,7 +697,7 @@
                 if (u.id === 1) {
                     html += '<div class="text-secondary text-center small py-1">' + _I18N.profileOwnerLocked + '</div>';
                 } else {
-                    html += '<a href="/jellyseerr/utilisateurs/' + u.id + '" class="btn btn-primary w-100">';
+                    html += '<a href="' + BASE + '/jellyseerr/utilisateurs/' + u.id + '" class="btn btn-primary w-100">';
                     html += '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="me-1"><path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 0 0 2.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 0 0 1.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 0 0-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 0 0-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 0 0-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 0 0-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 0 0 1.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><circle cx="12" cy="12" r="3"/></svg>';
                     html += _I18N.profileManageUser + '</a>';
                 }

--- a/symfony/templates/media/films.html.twig
+++ b/symfony/templates/media/films.html.twig
@@ -1081,6 +1081,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
 {% block javascripts %}
 <script>
 (function () {
+  var BASE = '{{ app.request.getBasePath() }}';
   /* ══════════════════════════════════════════════════════════════════════════
      i18n injection (FR source of truth ; locale bascule via ?_locale=en)
      ══════════════════════════════════════════════════════════════════════════ */
@@ -1412,7 +1413,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
   // the server (so bulk-filtered actions hit the whole filtered scope, not
   // just the items rendered on the current page).
   function fetchFilteredIds(extra) {
-    var url = '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/filter/ids?' + currentFilterParams(extra || {});
+    var url = BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/filter/ids?' + currentFilterParams(extra || {});
     return ajaxGet(url).then(function(data) {
       return (data && Array.isArray(data.ids)) ? data.ids : [];
     });
@@ -1481,7 +1482,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
       btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + ids.length + '...';
       showPageBannerHtml('<span class="spinner-border spinner-border-sm me-2"></span> ' + tpl(FILM_I18N.w_update_tpl, {COUNT: ids.length}), 'info');
 
-      return ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/bulk/refresh', { movieIds: ids })
+      return ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/bulk/refresh', { movieIds: ids })
       .then(function(data) {
         btn.disabled = false;
         btn.innerHTML = originalHtml;
@@ -1522,7 +1523,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
       btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + ids.length + '...';
       showPageBannerHtml('<span class="spinner-border spinner-border-sm me-2"></span> ' + tpl(FILM_I18N.w_search_progress_tpl, {COUNT: ids.length, IDX: INDEXER_COUNT}), 'info');
 
-      return ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/bulk/search', { movieIds: ids })
+      return ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/bulk/search', { movieIds: ids })
     .then(function(data) {
       if (data.ok && data.cmdId) {
         // Poll le statut de la commande
@@ -1532,7 +1533,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
         var bulkPoll = setInterval(function() {
           bulkPollCount++;
           var elapsed = bulkPollCount * 2;
-          ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId)
+          ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId)
           .then(function(cmd) {
             var st = (cmd.status || '').toLowerCase();
             var msg = cmd.message || '';
@@ -1848,7 +1849,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     var extrasEl = document.getElementById('film-extras');
     extrasEl.style.display = 'none';
     if (m.hasFile && m.id) {
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + m.id + '/extras').then(function(extras) {
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + m.id + '/extras').then(function(extras) {
         if (!extras || !extras.length) {
           extrasEl.textContent = FILM_I18N.no_extras;
         } else {
@@ -1908,8 +1909,8 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     titlesTbody.innerHTML = '';
 
     Promise.all([
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + movieId + '/credits'),
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/person/following')
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + movieId + '/credits'),
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/person/following')
     ])
     .then(function (results) {
       var credits = results[0] || [];
@@ -1939,14 +1940,14 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
               bm.querySelector('svg').setAttribute('fill', 'none');
               bm.querySelector('svg').setAttribute('stroke', 'rgba(255,255,255,.4)');
               bm.classList.remove('active');
-              ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/person/unfollow', { listId: parseInt(lid) });
+              ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/person/unfollow', { listId: parseInt(lid) });
               delete following[tmdbId];
             } else {
               // Follow
               bm.querySelector('svg').setAttribute('fill', '#6366f1');
               bm.querySelector('svg').setAttribute('stroke', '#6366f1');
               bm.classList.add('active');
-              ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/person/follow', {
+              ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/person/follow', {
                 personTmdbId: tmdbId,
                 personName: personName,
                 type: personType,
@@ -2054,7 +2055,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     timeline.innerHTML     = '';
     empty.style.display    = 'none';
 
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + movieId + '/history')
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + movieId + '/history')
     .then(function (items) {
       loading.style.display = 'none';
       if (!items.length) { empty.style.display = ''; return; }
@@ -2160,7 +2161,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + FILM_I18N.search_launch;
     showSearchFeedback(tpl(FILM_I18N.search_start_tpl, {TITLE: movieTitle}), 'info', true);
 
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/search')
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/search')
     .then(function (data) {
       if (!data.ok || !data.cmdId) {
         btn.disabled = false;
@@ -2177,7 +2178,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
 
       pollTimer = setInterval(function () {
         pollCount++;
-        ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId)
+        ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId)
         .then(function (cmd) {
           var st = (cmd.status || '').toLowerCase();
 
@@ -2188,8 +2189,8 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
 
             // Step 3: check the queue and history for the result
             Promise.all([
-              ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/history'),
-              ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue')
+              ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/history'),
+              ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue')
             ]).then(function (results) {
               var history = results[0] || [];
               var queue = results[1] || {};
@@ -2236,7 +2237,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
                   showSearchFeedback(msgs[msgIdx] + tpl(FILM_I18N.search_progress_elapsed_tpl, {SEC: releaseTimer}), 'info', true);
                 }, 1000);
 
-                ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/releases')
+                ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/releases')
                 .then(function(releases) {
                   clearInterval(releaseCountdown);
                   var approved = (releases || []).filter(function(r) { return r.approved; });
@@ -2245,7 +2246,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
                   if (approved.length > 0) {
                     showSearchFeedback(tpl(FILM_I18N.search_results_grab_best_tpl, {TOTAL: total, APPR: approved.length}), 'info', true);
                     var best = approved[0];
-                    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/grab', { guid: best.guid, indexerId: best.indexerId })
+                    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/grab', { guid: best.guid, indexerId: best.indexerId })
                     .then(function(gd) {
                       if (gd.ok) {
                         showSearchFeedback(tpl(FILM_I18N.search_grab_started_tpl, {INDEXER: best.indexer, TITLE: best.title.substring(0, 50)}), 'success', false);
@@ -2318,7 +2319,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     empty.style.display     = 'none';
     tbody.innerHTML         = '';
 
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/releases')
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/releases')
     .then(function (releases) {
       loading.style.display = 'none';
       if (!releases.length) { empty.style.display = ''; return; }
@@ -2418,7 +2419,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     var relTitle = row ? row.querySelector('td').textContent.trim() : '';
     btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:.7rem;height:.7rem"></span>';
 
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/grab', { guid: btn.dataset.guid, indexerId: parseInt(btn.dataset.indexer) })
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/grab', { guid: btn.dataset.guid, indexerId: parseInt(btn.dataset.indexer) })
     .then(function (data) {
       if (data.ok) {
         btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>';
@@ -2446,7 +2447,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     btn.disabled = true;
     showSearchFeedback(FILM_I18N.refresh_in_progress, 'info', true);
 
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/refresh')
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/refresh')
     .then(function (data) {
       if (!data.ok || !data.cmdId) {
         btn.disabled = false;
@@ -2454,7 +2455,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
         return;
       }
       pollTimer = setInterval(function () {
-        ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId)
+        ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId)
         .then(function (cmd) {
           var st = (cmd.status || '').toLowerCase();
           if (st === 'completed') {
@@ -2463,7 +2464,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
             showSearchFeedback(FILM_I18N.refresh_done, 'success', false);
             setTimeout(hideSearchFeedback, 4000);
             // Refresh infos du film
-            ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/info').then(function(movie) {
+            ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/info').then(function(movie) {
               if (!movie || !movie.id) return;
               currentMovie = movie;
               var card = grid.querySelector('[data-id="' + currentId + '"]');
@@ -2494,7 +2495,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     var newMon = !currentMonitored;
     btn.disabled = true;
 
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/monitor', { monitored: newMon })
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/monitor', { monitored: newMon })
     .then(function (data) {
       btn.disabled = false;
       if (data.ok) {
@@ -2551,7 +2552,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     content.innerHTML = '';
     feedback.style.display = 'none';
 
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/config').then(function(config) {
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/config').then(function(config) {
       editCardLoaded = true;
       loading.style.display = 'none';
       var m = currentMovie;
@@ -2637,7 +2638,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
         var val = input.value.trim();
         if (!val) return;
         input.value = '';
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/config/tag', { label: val }).then(function(data) {
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/config/tag', { label: val }).then(function(data) {
           if (data.ok && data.tag) {
             var container = document.getElementById('edit-tags-container');
             var lbl = document.createElement('label');
@@ -2662,7 +2663,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
       function browsePath(path) {
         browser.style.display = '';
         browser.innerHTML = '<div class="p-2 text-muted small"><span class="spinner-border spinner-border-sm me-1"></span></div>';
-        ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/filesystem?path=' + encodeURIComponent(path)).then(function(data) {
+        ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/filesystem?path=' + encodeURIComponent(path)).then(function(data) {
           var dirs = data.directories || [];
           var parentPath = data.parent || '/';
           var h = '';
@@ -2693,7 +2694,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
       document.getElementById('edit-path-update').addEventListener('click', function() {
         var newPath = document.getElementById('edit-path').value;
         if (!newPath || !confirm(tpl(FILM_I18N.edit_update_path_confirm_tpl, {PATH: newPath}))) return;
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/edit', { path: newPath }).then(function(data) {
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/edit', { path: newPath }).then(function(data) {
           if (data.ok) showPageBanner(FILM_I18N.banner_path_update, 'success');
         });
       });
@@ -2711,7 +2712,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
       document.getElementById('edit-delete-movie').addEventListener('click', function() {
         if (!confirm(tpl(FILM_I18N.edit_delete_confirm_tpl, {TITLE: m.title || ''}))) return;
         var deleteFiles = confirm(FILM_I18N.edit_delete_files_confirm);
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/delete', { deleteFiles: deleteFiles }).then(function() {
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/delete', { deleteFiles: deleteFiles }).then(function() {
           var card = grid.querySelector('[data-id="' + currentId + '"]');
           if (card) card.remove();
           closeEditCard();
@@ -2727,7 +2728,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
         content.querySelectorAll('.edit-tag-cb:checked').forEach(function(cb) {
           selectedTags.push(parseInt(cb.value));
         });
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/edit', {
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/edit', {
           monitored: document.getElementById('edit-monitored').checked,
           minimumAvailability: document.getElementById('edit-availability').value,
           qualityProfileId: parseInt(document.getElementById('edit-qualityProfile').value),
@@ -2801,7 +2802,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     deleteStatusMsg(FILM_I18N.delete_in_progress, 'muted');
 
     if (removeFromRadarr) {
-      ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/delete', { deleteFiles: deleteFiles })
+      ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/delete', { deleteFiles: deleteFiles })
       .then(function (data) {
         if (data.ok) {
           deleteStatusMsg(FILM_I18N.delete_success, 'success');
@@ -2811,10 +2812,10 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
         } else { deleteStatusMsg(FILM_I18N.delete_error_msg, 'danger'); }
       }).catch(function () { deleteStatusMsg(FILM_I18N.network_error, 'danger'); });
     } else {
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/files')
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/files')
       .then(function (files) {
         if (!files || !files.length) { deleteStatusMsg(FILM_I18N.no_file_found, 'danger'); return Promise.reject('no file'); }
-        return ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/files/' + files[0].id + '/delete');
+        return ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/files/' + files[0].id + '/delete');
       })
       .then(function (data) {
         if (data && data.ok) {
@@ -2890,7 +2891,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     // Show current filename from movieFile
     var curName = (currentMovie.movieFile && currentMovie.movieFile.relativePath) ? currentMovie.movieFile.relativePath : '';
 
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + movieId + '/rename-preview')
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + movieId + '/rename-preview')
     .then(function (proposals) {
       loading.style.display = 'none';
       if (!proposals || !proposals.length) {
@@ -2956,7 +2957,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + FILM_I18N.rename_launch;
     showRenameFeedback(FILM_I18N.rename_launch_start, 'info', true);
 
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/rename')
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/rename')
     .then(function (data) {
       if (!data.ok || !data.cmdId) {
         btn.disabled = false;
@@ -2967,7 +2968,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
 
       // Poll command status
       var renamePoll = setInterval(function () {
-        ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId)
+        ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId)
         .then(function (cmd) {
           var st = (cmd.status || '').toLowerCase();
           if (st === 'completed') {
@@ -2976,7 +2977,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
             btn.innerHTML = RENAME_SVG + FILM_I18N.rename_label;
             showRenameFeedback(FILM_I18N.rename_success, 'success', false);
             // Refetch the movie from the API to update the cache
-            ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/detail')
+            ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/detail')
             .then(function(freshMovie) {
               if (freshMovie && freshMovie.movieFile) {
                 currentMovie.movieFile = freshMovie.movieFile;
@@ -3072,10 +3073,10 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     content.innerHTML     = '';
 
     // Fetch files + quality definitions in parallel
-    var pFiles = ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + movieId + '/files');
+    var pFiles = ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + movieId + '/files');
     var pQuals = qualityDefsCache
       ? Promise.resolve(qualityDefsCache)
-      : ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/quality-definitions');
+      : ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/quality-definitions');
 
     Promise.all([pFiles, pQuals]).then(function (results) {
       var files = results[0] || [];
@@ -3219,7 +3220,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
         if (!confirm(FILM_I18N.delete_file_confirm)) return;
         btn.disabled = true;
         btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/files/' + fId + '/delete')
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/files/' + fId + '/delete')
         .then(function (data) {
           if (data && data.ok) {
             showFileManagerFeedback(FILM_I18N.file_deleted, 'success');
@@ -3326,7 +3327,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     btn.disabled = true;
     btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + FILM_I18N.saving;
 
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/files/' + fileId + '/update', payload)
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/files/' + fileId + '/update', payload)
     .then(function (data) {
       if (data.ok) {
         showFileManagerFeedback(FILM_I18N.saved, 'success');
@@ -3380,7 +3381,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     if (bannerLocked) return;
     var el = document.getElementById('warnings-banner');
     if (!el) return;
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/warnings?_t=' + Date.now()).then(function(warnings) {
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/warnings?_t=' + Date.now()).then(function(warnings) {
       if (!warnings || !warnings.length) {
         el.innerHTML = '';
         return;
@@ -3544,11 +3545,11 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
         if (progCell) progCell.innerHTML = '<div class="d-flex align-items-center gap-2"><div class="queue-progress flex-grow-1"><div class="queue-progress-bar" style="width:100%;background:#9b59b6;animation:pulse 1.5s infinite"></div></div><span style="color:#9b59b6" class="small fw-medium">' + esc(FILM_I18N.q_importing) + '</span></div>';
         if (statusCell) statusCell.innerHTML = '<span class="badge bg-purple-lt text-purple">' + esc(FILM_I18N.q_status_importing) + '</span>';
 
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue/' + queueId + '/import', {})
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue/' + queueId + '/import', {})
         .then(function(data) {
           if (data.ok && data.cmdId) {
             var importPoll = setInterval(function() {
-              ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId).then(function(cmd) {
+              ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId).then(function(cmd) {
                 var st = (cmd.status || '').toLowerCase();
                 var msg = cmd.message || '';
                 if (progCell && st === 'started') {
@@ -3560,8 +3561,8 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
                   if (progCell) progCell.innerHTML = '<div class="d-flex align-items-center gap-2"><div class="queue-progress flex-grow-1"><div class="queue-progress-bar bg-success" style="width:100%"></div></div><span class="text-success small fw-medium">' + esc(FILM_I18N.q_import_done_status) + '</span></div>';
                   if (statusCell) statusCell.innerHTML = '<span class="badge bg-success-lt text-success">' + esc(FILM_I18N.q_import_done_status) + '</span>';
                   btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2.5"><path d="M20 6 9 17l-5-5"/></svg>';
-                  ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue/' + queueId + '/delete', { blacklist: false, skipReimport: true }).catch(function(){});
-                  if (btn.dataset.movieId) ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + btn.dataset.movieId + '/rescan', {}).catch(function(){});
+                  ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue/' + queueId + '/delete', { blacklist: false, skipReimport: true }).catch(function(){});
+                  if (btn.dataset.movieId) ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + btn.dataset.movieId + '/rescan', {}).catch(function(){});
                   setTimeout(refreshQueue, 2000);
                 } else if (st === 'failed') {
                   clearInterval(importPoll);
@@ -3593,7 +3594,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
       if (btn._bound) return; btn._bound = true;
       btn.addEventListener('click', function() {
         btn.disabled = true;
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue/' + btn.dataset.id + '/grab', {}).then(function(data) {
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue/' + btn.dataset.id + '/grab', {}).then(function(data) {
           if (data.ok) refreshQueue();
           else btn.disabled = false;
         });
@@ -3630,7 +3631,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
           var blocklist = document.getElementById('qd-blocklist-' + queueId).checked;
           btn.disabled = true;
           optRow.remove();
-          ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue/' + queueId + '/delete', {
+          ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue/' + queueId + '/delete', {
             removeFromClient: removeFromClient,
             blocklist: blocklist,
             skipReimport: false
@@ -3649,7 +3650,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
 
   // Detect active commands on page load (ManualImport + searches)
   var RADARR_POLL_CMDS = {'MoviesSearch':1,'MissingMoviesSearch':1,'RenameMovie':1,'ManualImport':1};
-  ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/commands/active').then(function(cmds) {
+  ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/commands/active').then(function(cmds) {
     if (!cmds || !cmds.length) return;
     cmds.forEach(function(cmd) {
       if (!cmd.id) return;
@@ -3674,7 +3675,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
       var pollCmd = setInterval(function() {
         pollCount++;
         var elapsed = pollCount * 2;
-        ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + cmd.id).then(function(st) {
+        ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + cmd.id).then(function(st) {
           var status = (st.status || '').toLowerCase();
           var msg = st.message || '';
           if (status === 'completed') {
@@ -3720,9 +3721,9 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     refreshCount++;
     // Every 3 refreshes (6s), force Radarr to query qBittorrent
     if (refreshCount % 3 === 1) {
-      ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/refresh-downloads', {}).catch(function(){});
+      ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/refresh-downloads', {}).catch(function(){});
     }
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue?_t=' + Date.now()).then(function(items) {
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue?_t=' + Date.now()).then(function(items) {
       var currentIds = new Set();
       (items || []).forEach(function(q) { if (q.movieId) currentIds.add(q.movieId); });
 
@@ -3758,7 +3759,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
 
             // Si la modal est ouverte pour ce film → rafraîchir les infos
             if (currentId && String(currentId) === String(mid)) {
-              ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + mid + '/info').then(function(movie) {
+              ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + mid + '/info').then(function(movie) {
                 if (!movie || !movie.id) return;
                 currentMovie = movie;
                 try { card.dataset.movie = JSON.stringify(movie); } catch(e) {}
@@ -3814,7 +3815,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     results.innerHTML = '';
     document.getElementById('add-film-form').style.display = 'none';
 
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/lookup?term=' + encodeURIComponent(term))
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/lookup?term=' + encodeURIComponent(term))
     .then(function (movies) {
       loading.style.display = 'none';
       if (!movies.length) {
@@ -3881,7 +3882,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     document.getElementById('add-film-form').scrollIntoView({ behavior: 'smooth', block: 'nearest' });
 
     if (!configLoaded) {
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/config')
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/config')
       .then(function (cfg) {
         configData = cfg; configLoaded = true;
         var qualSel   = document.getElementById('add-quality-select');
@@ -3944,7 +3945,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     result.className = 'mt-3 alert alert-info'; result.classList.remove('d-none');
     result.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span> ' + FILM_I18N.m_adding;
 
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/add', {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/add', {
       tmdbId:           parseInt(selectedMovie.tmdbId),
       title:            selectedMovie.title,
       year:             parseInt(selectedMovie.year),
@@ -3975,8 +3976,8 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
             result.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span> ' + tpl(FILM_I18N.m_searching_dots_tpl, {DOTS: dots}) + (elapsed >= 9 ? tpl(FILM_I18N.m_searching_elapsed_tpl, {SEC: elapsed}) : '');
 
             Promise.all([
-              ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue?_t=' + Date.now()),
-              ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + movieId + '/history')
+              ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue?_t=' + Date.now()),
+              ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + movieId + '/history')
             ]).then(function(results) {
               var queue = results[0];
               var history = results[1] || [];
@@ -4045,7 +4046,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     showPageBannerHtml('<span class="spinner-border spinner-border-sm me-2"></span> ' + tpl(FILM_I18N.w_cmd_in_progress_tpl, {LBL: label}), 'info');
     var timer = setInterval(function() {
       pollCount++;
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + cmdId).then(function(cmd) {
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + cmdId).then(function(cmd) {
         var st = (cmd.status || '').toLowerCase();
         var msg = cmd.message || '';
         if (st === 'completed') {
@@ -4064,7 +4065,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
 
   document.getElementById('btn-refresh-all').addEventListener('click', function() {
     var btn = this; btn.disabled = true;
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/refresh-all', {}).then(function(d) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/refresh-all', {}).then(function(d) {
       btn.disabled = false;
       if (d.ok && d.cmdId) pollFilmCmd(d.cmdId, FILM_I18N.w_refresh_label);
       else showPageBanner(FILM_I18N.w_generic_error, 'danger');
@@ -4073,7 +4074,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
 
   document.getElementById('btn-rss-sync').addEventListener('click', function() {
     var btn = this; btn.disabled = true;
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/rss-sync', {}).then(function(d) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/rss-sync', {}).then(function(d) {
       btn.disabled = false;
       if (d.ok && d.cmdId) pollFilmCmd(d.cmdId, FILM_I18N.w_rss_label);
       else showPageBanner(FILM_I18N.w_generic_error, 'danger');
@@ -4244,7 +4245,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     var id = btn.dataset.id;
     var mon = btn.dataset.monitored === '1';
     var newMon = !mon;
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + id + '/monitor', { monitored: newMon }).then(function(data) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + id + '/monitor', { monitored: newMon }).then(function(data) {
       if (data.ok) {
         btn.dataset.monitored = newMon ? '1' : '0';
         var svg = btn.querySelector('svg');
@@ -4358,7 +4359,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
   // Load config for bulk modals (lazy)
   function ensureBulkConfig(cb) {
     if (bulkConfigCache) { cb(bulkConfigCache); return; }
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/config').then(function(config) {
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/config').then(function(config) {
       bulkConfigCache = config;
       cb(config);
     });
@@ -4432,7 +4433,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     if (avail) payload.minimumAvailability = avail;
     if (root) payload.rootFolderPath = root;
     var btn = this; btn.disabled = true; btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/bulk/edit', payload).then(function(d) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/bulk/edit', payload).then(function(d) {
       btn.disabled = false; btn.innerHTML = FILM_I18N.b_save;
       closeBulkModal('modal-bulk-edit');
       if (d.ok) { showPageBanner(tpl(FILM_I18N.w_bulk_modified_tpl, {COUNT: ids.length}), 'success'); setTimeout(function() { location.reload(); }, 1500); }
@@ -4465,7 +4466,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     var tagIds = []; document.querySelectorAll('.bulk-tag-cb:checked').forEach(function(cb) { tagIds.push(parseInt(cb.value)); });
     if (!tagIds.length) return;
     var btn = this; btn.disabled = true; btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/bulk/edit', { movieIds: ids, tags: tagIds, applyTags: document.getElementById('bulk-tags-action').value }).then(function(d) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/bulk/edit', { movieIds: ids, tags: tagIds, applyTags: document.getElementById('bulk-tags-action').value }).then(function(d) {
       btn.disabled = false; btn.innerHTML = FILM_I18N.b_apply;
       closeBulkModal('modal-bulk-tags');
       if (d.ok) showPageBanner(tpl(FILM_I18N.w_bulk_tags_ok_tpl, {COUNT: ids.length}), 'success');
@@ -4498,7 +4499,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     ids.forEach(function(mid) {
       var card = grid.querySelector('[data-id="' + mid + '"]');
       var title = card ? (card.getAttribute('title') || '?') : '?';
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + mid + '/rename-preview').then(function(proposals) {
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + mid + '/rename-preview').then(function(proposals) {
         loaded++;
         if (proposals && proposals.length) {
           renameMovieIds.push(mid);
@@ -4542,7 +4543,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     var btn = this; btn.disabled = true; btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
     var done = 0;
     renameMovieIds.forEach(function(mid) {
-      ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + mid + '/rename', {}).then(function() {
+      ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + mid + '/rename', {}).then(function() {
         done++;
         if (done >= renameMovieIds.length) { btn.disabled = false; btn.innerHTML = FILM_I18N.b_organise; closeBulkModal('modal-bulk-rename'); showPageBanner(tpl(FILM_I18N.w_bulk_rename_ok_tpl, {COUNT: renameMovieIds.length}), 'success'); }
       }).catch(function() { done++; });
@@ -4563,7 +4564,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
   document.getElementById('bulk-delete-confirm').addEventListener('click', function() {
     var ids = Array.from(selectedIds).map(Number);
     var btn = this; btn.disabled = true; btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/bulk/delete', { movieIds: ids, deleteFiles: document.getElementById('bulk-delete-files').checked, addExclusion: document.getElementById('bulk-delete-exclude').checked }).then(function(d) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/bulk/delete', { movieIds: ids, deleteFiles: document.getElementById('bulk-delete-files').checked, addExclusion: document.getElementById('bulk-delete-exclude').checked }).then(function(d) {
       btn.disabled = false; btn.innerHTML = FILM_I18N.b_delete;
       closeBulkModal('modal-bulk-delete');
       if (d.ok) {

--- a/symfony/templates/media/films.html.twig
+++ b/symfony/templates/media/films.html.twig
@@ -1081,6 +1081,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
 {% block javascripts %}
 <script>
 (function () {
+  var BASE = window.BASE_PATH;
   /* ══════════════════════════════════════════════════════════════════════════
      i18n injection (FR source of truth ; locale bascule via ?_locale=en)
      ══════════════════════════════════════════════════════════════════════════ */
@@ -1412,7 +1413,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
   // the server (so bulk-filtered actions hit the whole filtered scope, not
   // just the items rendered on the current page).
   function fetchFilteredIds(extra) {
-    var url = '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/filter/ids?' + currentFilterParams(extra || {});
+    var url = BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/filter/ids?' + currentFilterParams(extra || {});
     return ajaxGet(url).then(function(data) {
       return (data && Array.isArray(data.ids)) ? data.ids : [];
     });
@@ -1481,7 +1482,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
       btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + ids.length + '...';
       showPageBannerHtml('<span class="spinner-border spinner-border-sm me-2"></span> ' + tpl(FILM_I18N.w_update_tpl, {COUNT: ids.length}), 'info');
 
-      return ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/bulk/refresh', { movieIds: ids })
+      return ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/bulk/refresh', { movieIds: ids })
       .then(function(data) {
         btn.disabled = false;
         btn.innerHTML = originalHtml;
@@ -1522,7 +1523,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
       btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + ids.length + '...';
       showPageBannerHtml('<span class="spinner-border spinner-border-sm me-2"></span> ' + tpl(FILM_I18N.w_search_progress_tpl, {COUNT: ids.length, IDX: INDEXER_COUNT}), 'info');
 
-      return ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/bulk/search', { movieIds: ids })
+      return ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/bulk/search', { movieIds: ids })
     .then(function(data) {
       if (data.ok && data.cmdId) {
         // Poll le statut de la commande
@@ -1532,7 +1533,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
         var bulkPoll = setInterval(function() {
           bulkPollCount++;
           var elapsed = bulkPollCount * 2;
-          ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId)
+          ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId)
           .then(function(cmd) {
             var st = (cmd.status || '').toLowerCase();
             var msg = cmd.message || '';
@@ -1848,7 +1849,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     var extrasEl = document.getElementById('film-extras');
     extrasEl.style.display = 'none';
     if (m.hasFile && m.id) {
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + m.id + '/extras').then(function(extras) {
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + m.id + '/extras').then(function(extras) {
         if (!extras || !extras.length) {
           extrasEl.textContent = FILM_I18N.no_extras;
         } else {
@@ -1908,8 +1909,8 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     titlesTbody.innerHTML = '';
 
     Promise.all([
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + movieId + '/credits'),
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/person/following')
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + movieId + '/credits'),
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/person/following')
     ])
     .then(function (results) {
       var credits = results[0] || [];
@@ -1939,14 +1940,14 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
               bm.querySelector('svg').setAttribute('fill', 'none');
               bm.querySelector('svg').setAttribute('stroke', 'rgba(255,255,255,.4)');
               bm.classList.remove('active');
-              ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/person/unfollow', { listId: parseInt(lid) });
+              ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/person/unfollow', { listId: parseInt(lid) });
               delete following[tmdbId];
             } else {
               // Follow
               bm.querySelector('svg').setAttribute('fill', '#6366f1');
               bm.querySelector('svg').setAttribute('stroke', '#6366f1');
               bm.classList.add('active');
-              ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/person/follow', {
+              ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/person/follow', {
                 personTmdbId: tmdbId,
                 personName: personName,
                 type: personType,
@@ -2054,7 +2055,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     timeline.innerHTML     = '';
     empty.style.display    = 'none';
 
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + movieId + '/history')
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + movieId + '/history')
     .then(function (items) {
       loading.style.display = 'none';
       if (!items.length) { empty.style.display = ''; return; }
@@ -2160,7 +2161,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + FILM_I18N.search_launch;
     showSearchFeedback(tpl(FILM_I18N.search_start_tpl, {TITLE: movieTitle}), 'info', true);
 
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/search')
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/search')
     .then(function (data) {
       if (!data.ok || !data.cmdId) {
         btn.disabled = false;
@@ -2177,7 +2178,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
 
       pollTimer = setInterval(function () {
         pollCount++;
-        ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId)
+        ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId)
         .then(function (cmd) {
           var st = (cmd.status || '').toLowerCase();
 
@@ -2188,8 +2189,8 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
 
             // Step 3: check the queue and history for the result
             Promise.all([
-              ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/history'),
-              ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue')
+              ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/history'),
+              ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue')
             ]).then(function (results) {
               var history = results[0] || [];
               var queue = results[1] || {};
@@ -2236,7 +2237,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
                   showSearchFeedback(msgs[msgIdx] + tpl(FILM_I18N.search_progress_elapsed_tpl, {SEC: releaseTimer}), 'info', true);
                 }, 1000);
 
-                ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/releases')
+                ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/releases')
                 .then(function(releases) {
                   clearInterval(releaseCountdown);
                   var approved = (releases || []).filter(function(r) { return r.approved; });
@@ -2245,7 +2246,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
                   if (approved.length > 0) {
                     showSearchFeedback(tpl(FILM_I18N.search_results_grab_best_tpl, {TOTAL: total, APPR: approved.length}), 'info', true);
                     var best = approved[0];
-                    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/grab', { guid: best.guid, indexerId: best.indexerId })
+                    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/grab', { guid: best.guid, indexerId: best.indexerId })
                     .then(function(gd) {
                       if (gd.ok) {
                         showSearchFeedback(tpl(FILM_I18N.search_grab_started_tpl, {INDEXER: best.indexer, TITLE: best.title.substring(0, 50)}), 'success', false);
@@ -2318,7 +2319,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     empty.style.display     = 'none';
     tbody.innerHTML         = '';
 
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/releases')
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/releases')
     .then(function (releases) {
       loading.style.display = 'none';
       if (!releases.length) { empty.style.display = ''; return; }
@@ -2418,7 +2419,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     var relTitle = row ? row.querySelector('td').textContent.trim() : '';
     btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:.7rem;height:.7rem"></span>';
 
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/grab', { guid: btn.dataset.guid, indexerId: parseInt(btn.dataset.indexer) })
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/grab', { guid: btn.dataset.guid, indexerId: parseInt(btn.dataset.indexer) })
     .then(function (data) {
       if (data.ok) {
         btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>';
@@ -2446,7 +2447,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     btn.disabled = true;
     showSearchFeedback(FILM_I18N.refresh_in_progress, 'info', true);
 
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/refresh')
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/refresh')
     .then(function (data) {
       if (!data.ok || !data.cmdId) {
         btn.disabled = false;
@@ -2454,7 +2455,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
         return;
       }
       pollTimer = setInterval(function () {
-        ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId)
+        ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId)
         .then(function (cmd) {
           var st = (cmd.status || '').toLowerCase();
           if (st === 'completed') {
@@ -2463,7 +2464,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
             showSearchFeedback(FILM_I18N.refresh_done, 'success', false);
             setTimeout(hideSearchFeedback, 4000);
             // Refresh infos du film
-            ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/info').then(function(movie) {
+            ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/info').then(function(movie) {
               if (!movie || !movie.id) return;
               currentMovie = movie;
               var card = grid.querySelector('[data-id="' + currentId + '"]');
@@ -2494,7 +2495,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     var newMon = !currentMonitored;
     btn.disabled = true;
 
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/monitor', { monitored: newMon })
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/monitor', { monitored: newMon })
     .then(function (data) {
       btn.disabled = false;
       if (data.ok) {
@@ -2551,7 +2552,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     content.innerHTML = '';
     feedback.style.display = 'none';
 
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/config').then(function(config) {
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/config').then(function(config) {
       editCardLoaded = true;
       loading.style.display = 'none';
       var m = currentMovie;
@@ -2637,7 +2638,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
         var val = input.value.trim();
         if (!val) return;
         input.value = '';
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/config/tag', { label: val }).then(function(data) {
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/config/tag', { label: val }).then(function(data) {
           if (data.ok && data.tag) {
             var container = document.getElementById('edit-tags-container');
             var lbl = document.createElement('label');
@@ -2662,7 +2663,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
       function browsePath(path) {
         browser.style.display = '';
         browser.innerHTML = '<div class="p-2 text-muted small"><span class="spinner-border spinner-border-sm me-1"></span></div>';
-        ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/filesystem?path=' + encodeURIComponent(path)).then(function(data) {
+        ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/filesystem?path=' + encodeURIComponent(path)).then(function(data) {
           var dirs = data.directories || [];
           var parentPath = data.parent || '/';
           var h = '';
@@ -2693,7 +2694,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
       document.getElementById('edit-path-update').addEventListener('click', function() {
         var newPath = document.getElementById('edit-path').value;
         if (!newPath || !confirm(tpl(FILM_I18N.edit_update_path_confirm_tpl, {PATH: newPath}))) return;
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/edit', { path: newPath }).then(function(data) {
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/edit', { path: newPath }).then(function(data) {
           if (data.ok) showPageBanner(FILM_I18N.banner_path_update, 'success');
         });
       });
@@ -2711,7 +2712,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
       document.getElementById('edit-delete-movie').addEventListener('click', function() {
         if (!confirm(tpl(FILM_I18N.edit_delete_confirm_tpl, {TITLE: m.title || ''}))) return;
         var deleteFiles = confirm(FILM_I18N.edit_delete_files_confirm);
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/delete', { deleteFiles: deleteFiles }).then(function() {
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/delete', { deleteFiles: deleteFiles }).then(function() {
           var card = grid.querySelector('[data-id="' + currentId + '"]');
           if (card) card.remove();
           closeEditCard();
@@ -2727,7 +2728,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
         content.querySelectorAll('.edit-tag-cb:checked').forEach(function(cb) {
           selectedTags.push(parseInt(cb.value));
         });
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/edit', {
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/edit', {
           monitored: document.getElementById('edit-monitored').checked,
           minimumAvailability: document.getElementById('edit-availability').value,
           qualityProfileId: parseInt(document.getElementById('edit-qualityProfile').value),
@@ -2801,7 +2802,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     deleteStatusMsg(FILM_I18N.delete_in_progress, 'muted');
 
     if (removeFromRadarr) {
-      ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/delete', { deleteFiles: deleteFiles })
+      ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/delete', { deleteFiles: deleteFiles })
       .then(function (data) {
         if (data.ok) {
           deleteStatusMsg(FILM_I18N.delete_success, 'success');
@@ -2811,10 +2812,10 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
         } else { deleteStatusMsg(FILM_I18N.delete_error_msg, 'danger'); }
       }).catch(function () { deleteStatusMsg(FILM_I18N.network_error, 'danger'); });
     } else {
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/files')
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/files')
       .then(function (files) {
         if (!files || !files.length) { deleteStatusMsg(FILM_I18N.no_file_found, 'danger'); return Promise.reject('no file'); }
-        return ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/files/' + files[0].id + '/delete');
+        return ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/files/' + files[0].id + '/delete');
       })
       .then(function (data) {
         if (data && data.ok) {
@@ -2890,7 +2891,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     // Show current filename from movieFile
     var curName = (currentMovie.movieFile && currentMovie.movieFile.relativePath) ? currentMovie.movieFile.relativePath : '';
 
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + movieId + '/rename-preview')
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + movieId + '/rename-preview')
     .then(function (proposals) {
       loading.style.display = 'none';
       if (!proposals || !proposals.length) {
@@ -2956,7 +2957,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + FILM_I18N.rename_launch;
     showRenameFeedback(FILM_I18N.rename_launch_start, 'info', true);
 
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/rename')
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/rename')
     .then(function (data) {
       if (!data.ok || !data.cmdId) {
         btn.disabled = false;
@@ -2967,7 +2968,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
 
       // Poll command status
       var renamePoll = setInterval(function () {
-        ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId)
+        ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId)
         .then(function (cmd) {
           var st = (cmd.status || '').toLowerCase();
           if (st === 'completed') {
@@ -2976,7 +2977,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
             btn.innerHTML = RENAME_SVG + FILM_I18N.rename_label;
             showRenameFeedback(FILM_I18N.rename_success, 'success', false);
             // Refetch the movie from the API to update the cache
-            ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/detail')
+            ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + currentId + '/detail')
             .then(function(freshMovie) {
               if (freshMovie && freshMovie.movieFile) {
                 currentMovie.movieFile = freshMovie.movieFile;
@@ -3072,10 +3073,10 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     content.innerHTML     = '';
 
     // Fetch files + quality definitions in parallel
-    var pFiles = ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + movieId + '/files');
+    var pFiles = ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + movieId + '/files');
     var pQuals = qualityDefsCache
       ? Promise.resolve(qualityDefsCache)
-      : ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/quality-definitions');
+      : ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/quality-definitions');
 
     Promise.all([pFiles, pQuals]).then(function (results) {
       var files = results[0] || [];
@@ -3219,7 +3220,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
         if (!confirm(FILM_I18N.delete_file_confirm)) return;
         btn.disabled = true;
         btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/files/' + fId + '/delete')
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/files/' + fId + '/delete')
         .then(function (data) {
           if (data && data.ok) {
             showFileManagerFeedback(FILM_I18N.file_deleted, 'success');
@@ -3326,7 +3327,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     btn.disabled = true;
     btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + FILM_I18N.saving;
 
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/files/' + fileId + '/update', payload)
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/files/' + fileId + '/update', payload)
     .then(function (data) {
       if (data.ok) {
         showFileManagerFeedback(FILM_I18N.saved, 'success');
@@ -3380,7 +3381,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     if (bannerLocked) return;
     var el = document.getElementById('warnings-banner');
     if (!el) return;
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/warnings?_t=' + Date.now()).then(function(warnings) {
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/warnings?_t=' + Date.now()).then(function(warnings) {
       if (!warnings || !warnings.length) {
         el.innerHTML = '';
         return;
@@ -3544,11 +3545,11 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
         if (progCell) progCell.innerHTML = '<div class="d-flex align-items-center gap-2"><div class="queue-progress flex-grow-1"><div class="queue-progress-bar" style="width:100%;background:#9b59b6;animation:pulse 1.5s infinite"></div></div><span style="color:#9b59b6" class="small fw-medium">' + esc(FILM_I18N.q_importing) + '</span></div>';
         if (statusCell) statusCell.innerHTML = '<span class="badge bg-purple-lt text-purple">' + esc(FILM_I18N.q_status_importing) + '</span>';
 
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue/' + queueId + '/import', {})
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue/' + queueId + '/import', {})
         .then(function(data) {
           if (data.ok && data.cmdId) {
             var importPoll = setInterval(function() {
-              ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId).then(function(cmd) {
+              ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId).then(function(cmd) {
                 var st = (cmd.status || '').toLowerCase();
                 var msg = cmd.message || '';
                 if (progCell && st === 'started') {
@@ -3560,8 +3561,8 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
                   if (progCell) progCell.innerHTML = '<div class="d-flex align-items-center gap-2"><div class="queue-progress flex-grow-1"><div class="queue-progress-bar bg-success" style="width:100%"></div></div><span class="text-success small fw-medium">' + esc(FILM_I18N.q_import_done_status) + '</span></div>';
                   if (statusCell) statusCell.innerHTML = '<span class="badge bg-success-lt text-success">' + esc(FILM_I18N.q_import_done_status) + '</span>';
                   btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2.5"><path d="M20 6 9 17l-5-5"/></svg>';
-                  ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue/' + queueId + '/delete', { blacklist: false, skipReimport: true }).catch(function(){});
-                  if (btn.dataset.movieId) ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + btn.dataset.movieId + '/rescan', {}).catch(function(){});
+                  ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue/' + queueId + '/delete', { blacklist: false, skipReimport: true }).catch(function(){});
+                  if (btn.dataset.movieId) ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + btn.dataset.movieId + '/rescan', {}).catch(function(){});
                   setTimeout(refreshQueue, 2000);
                 } else if (st === 'failed') {
                   clearInterval(importPoll);
@@ -3593,7 +3594,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
       if (btn._bound) return; btn._bound = true;
       btn.addEventListener('click', function() {
         btn.disabled = true;
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue/' + btn.dataset.id + '/grab', {}).then(function(data) {
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue/' + btn.dataset.id + '/grab', {}).then(function(data) {
           if (data.ok) refreshQueue();
           else btn.disabled = false;
         });
@@ -3630,7 +3631,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
           var blocklist = document.getElementById('qd-blocklist-' + queueId).checked;
           btn.disabled = true;
           optRow.remove();
-          ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue/' + queueId + '/delete', {
+          ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue/' + queueId + '/delete', {
             removeFromClient: removeFromClient,
             blocklist: blocklist,
             skipReimport: false
@@ -3649,7 +3650,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
 
   // Detect active commands on page load (ManualImport + searches)
   var RADARR_POLL_CMDS = {'MoviesSearch':1,'MissingMoviesSearch':1,'RenameMovie':1,'ManualImport':1};
-  ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/commands/active').then(function(cmds) {
+  ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/commands/active').then(function(cmds) {
     if (!cmds || !cmds.length) return;
     cmds.forEach(function(cmd) {
       if (!cmd.id) return;
@@ -3674,7 +3675,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
       var pollCmd = setInterval(function() {
         pollCount++;
         var elapsed = pollCount * 2;
-        ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + cmd.id).then(function(st) {
+        ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + cmd.id).then(function(st) {
           var status = (st.status || '').toLowerCase();
           var msg = st.message || '';
           if (status === 'completed') {
@@ -3720,9 +3721,9 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     refreshCount++;
     // Every 3 refreshes (6s), force Radarr to query qBittorrent
     if (refreshCount % 3 === 1) {
-      ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/refresh-downloads', {}).catch(function(){});
+      ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/refresh-downloads', {}).catch(function(){});
     }
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue?_t=' + Date.now()).then(function(items) {
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue?_t=' + Date.now()).then(function(items) {
       var currentIds = new Set();
       (items || []).forEach(function(q) { if (q.movieId) currentIds.add(q.movieId); });
 
@@ -3758,7 +3759,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
 
             // Si la modal est ouverte pour ce film → rafraîchir les infos
             if (currentId && String(currentId) === String(mid)) {
-              ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + mid + '/info').then(function(movie) {
+              ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + mid + '/info').then(function(movie) {
                 if (!movie || !movie.id) return;
                 currentMovie = movie;
                 try { card.dataset.movie = JSON.stringify(movie); } catch(e) {}
@@ -3814,7 +3815,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     results.innerHTML = '';
     document.getElementById('add-film-form').style.display = 'none';
 
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/lookup?term=' + encodeURIComponent(term))
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/lookup?term=' + encodeURIComponent(term))
     .then(function (movies) {
       loading.style.display = 'none';
       if (!movies.length) {
@@ -3881,7 +3882,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     document.getElementById('add-film-form').scrollIntoView({ behavior: 'smooth', block: 'nearest' });
 
     if (!configLoaded) {
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/config')
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/config')
       .then(function (cfg) {
         configData = cfg; configLoaded = true;
         var qualSel   = document.getElementById('add-quality-select');
@@ -3944,7 +3945,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     result.className = 'mt-3 alert alert-info'; result.classList.remove('d-none');
     result.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span> ' + FILM_I18N.m_adding;
 
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/add', {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/add', {
       tmdbId:           parseInt(selectedMovie.tmdbId),
       title:            selectedMovie.title,
       year:             parseInt(selectedMovie.year),
@@ -3975,8 +3976,8 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
             result.innerHTML = '<span class="spinner-border spinner-border-sm me-2"></span> ' + tpl(FILM_I18N.m_searching_dots_tpl, {DOTS: dots}) + (elapsed >= 9 ? tpl(FILM_I18N.m_searching_elapsed_tpl, {SEC: elapsed}) : '');
 
             Promise.all([
-              ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue?_t=' + Date.now()),
-              ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + movieId + '/history')
+              ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/queue?_t=' + Date.now()),
+              ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + movieId + '/history')
             ]).then(function(results) {
               var queue = results[0];
               var history = results[1] || [];
@@ -4045,7 +4046,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     showPageBannerHtml('<span class="spinner-border spinner-border-sm me-2"></span> ' + tpl(FILM_I18N.w_cmd_in_progress_tpl, {LBL: label}), 'info');
     var timer = setInterval(function() {
       pollCount++;
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + cmdId).then(function(cmd) {
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + cmdId).then(function(cmd) {
         var st = (cmd.status || '').toLowerCase();
         var msg = cmd.message || '';
         if (st === 'completed') {
@@ -4064,7 +4065,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
 
   document.getElementById('btn-refresh-all').addEventListener('click', function() {
     var btn = this; btn.disabled = true;
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/refresh-all', {}).then(function(d) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/refresh-all', {}).then(function(d) {
       btn.disabled = false;
       if (d.ok && d.cmdId) pollFilmCmd(d.cmdId, FILM_I18N.w_refresh_label);
       else showPageBanner(FILM_I18N.w_generic_error, 'danger');
@@ -4073,7 +4074,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
 
   document.getElementById('btn-rss-sync').addEventListener('click', function() {
     var btn = this; btn.disabled = true;
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/rss-sync', {}).then(function(d) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/rss-sync', {}).then(function(d) {
       btn.disabled = false;
       if (d.ok && d.cmdId) pollFilmCmd(d.cmdId, FILM_I18N.w_rss_label);
       else showPageBanner(FILM_I18N.w_generic_error, 'danger');
@@ -4244,7 +4245,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     var id = btn.dataset.id;
     var mon = btn.dataset.monitored === '1';
     var newMon = !mon;
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + id + '/monitor', { monitored: newMon }).then(function(data) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + id + '/monitor', { monitored: newMon }).then(function(data) {
       if (data.ok) {
         btn.dataset.monitored = newMon ? '1' : '0';
         var svg = btn.querySelector('svg');
@@ -4358,7 +4359,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
   // Load config for bulk modals (lazy)
   function ensureBulkConfig(cb) {
     if (bulkConfigCache) { cb(bulkConfigCache); return; }
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/config').then(function(config) {
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/config').then(function(config) {
       bulkConfigCache = config;
       cb(config);
     });
@@ -4432,7 +4433,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     if (avail) payload.minimumAvailability = avail;
     if (root) payload.rootFolderPath = root;
     var btn = this; btn.disabled = true; btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/bulk/edit', payload).then(function(d) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/bulk/edit', payload).then(function(d) {
       btn.disabled = false; btn.innerHTML = FILM_I18N.b_save;
       closeBulkModal('modal-bulk-edit');
       if (d.ok) { showPageBanner(tpl(FILM_I18N.w_bulk_modified_tpl, {COUNT: ids.length}), 'success'); setTimeout(function() { location.reload(); }, 1500); }
@@ -4465,7 +4466,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     var tagIds = []; document.querySelectorAll('.bulk-tag-cb:checked').forEach(function(cb) { tagIds.push(parseInt(cb.value)); });
     if (!tagIds.length) return;
     var btn = this; btn.disabled = true; btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/bulk/edit', { movieIds: ids, tags: tagIds, applyTags: document.getElementById('bulk-tags-action').value }).then(function(d) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/bulk/edit', { movieIds: ids, tags: tagIds, applyTags: document.getElementById('bulk-tags-action').value }).then(function(d) {
       btn.disabled = false; btn.innerHTML = FILM_I18N.b_apply;
       closeBulkModal('modal-bulk-tags');
       if (d.ok) showPageBanner(tpl(FILM_I18N.w_bulk_tags_ok_tpl, {COUNT: ids.length}), 'success');
@@ -4498,7 +4499,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     ids.forEach(function(mid) {
       var card = grid.querySelector('[data-id="' + mid + '"]');
       var title = card ? (card.getAttribute('title') || '?') : '?';
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + mid + '/rename-preview').then(function(proposals) {
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + mid + '/rename-preview').then(function(proposals) {
         loaded++;
         if (proposals && proposals.length) {
           renameMovieIds.push(mid);
@@ -4542,7 +4543,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
     var btn = this; btn.disabled = true; btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
     var done = 0;
     renameMovieIds.forEach(function(mid) {
-      ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + mid + '/rename', {}).then(function() {
+      ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + mid + '/rename', {}).then(function() {
         done++;
         if (done >= renameMovieIds.length) { btn.disabled = false; btn.innerHTML = FILM_I18N.b_organise; closeBulkModal('modal-bulk-rename'); showPageBanner(tpl(FILM_I18N.w_bulk_rename_ok_tpl, {COUNT: renameMovieIds.length}), 'success'); }
       }).catch(function() { done++; });
@@ -4563,7 +4564,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
   document.getElementById('bulk-delete-confirm').addEventListener('click', function() {
     var ids = Array.from(selectedIds).map(Number);
     var btn = this; btn.disabled = true; btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/bulk/delete', { movieIds: ids, deleteFiles: document.getElementById('bulk-delete-files').checked, addExclusion: document.getElementById('bulk-delete-exclude').checked }).then(function(d) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/bulk/delete', { movieIds: ids, deleteFiles: document.getElementById('bulk-delete-files').checked, addExclusion: document.getElementById('bulk-delete-exclude').checked }).then(function(d) {
       btn.disabled = false; btn.innerHTML = FILM_I18N.b_delete;
       closeBulkModal('modal-bulk-delete');
       if (d.ok) {

--- a/symfony/templates/media/films_blocklist.html.twig
+++ b/symfony/templates/media/films_blocklist.html.twig
@@ -128,6 +128,7 @@
 {% block javascripts %}
 <script>
 (function () {
+  var BASE = '{{ app.request.getBasePath() }}';
   var BL_I18N = {
     confirm_delete: {{ 'media.films_blocklist.confirm_delete'|trans|json_encode|raw }},
     confirm_bulk_delete_tpl: {{ 'media.films_blocklist.confirm_bulk_delete'|trans({count: '__COUNT__'})|json_encode|raw }},
@@ -170,7 +171,7 @@
       var row = this.closest('tr');
       if (!confirm(BL_I18N.confirm_delete)) return;
       btn.disabled = true;
-      postJson('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/blocklist/' + id + '/delete')
+      postJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/blocklist/' + id + '/delete')
       .then(function (data) {
         if (data.ok) row.remove();
         else { alert(BL_I18N.error); btn.disabled = false; }
@@ -186,7 +187,7 @@
     if (!confirm(BL_I18N.confirm_bulk_delete_tpl.replace('__COUNT__', checked.length))) return;
     var ids = Array.from(checked).map(function (c) { return parseInt(c.value); });
     bulkBtn.disabled = true;
-    postJson('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/blocklist/bulk-delete', { ids: ids })
+    postJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/blocklist/bulk-delete', { ids: ids })
     .then(function (data) {
       if (data.ok) {
         ids.forEach(function (id) {

--- a/symfony/templates/media/films_blocklist.html.twig
+++ b/symfony/templates/media/films_blocklist.html.twig
@@ -128,6 +128,7 @@
 {% block javascripts %}
 <script>
 (function () {
+  var BASE = window.BASE_PATH;
   var BL_I18N = {
     confirm_delete: {{ 'media.films_blocklist.confirm_delete'|trans|json_encode|raw }},
     confirm_bulk_delete_tpl: {{ 'media.films_blocklist.confirm_bulk_delete'|trans({count: '__COUNT__'})|json_encode|raw }},
@@ -170,7 +171,7 @@
       var row = this.closest('tr');
       if (!confirm(BL_I18N.confirm_delete)) return;
       btn.disabled = true;
-      postJson('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/blocklist/' + id + '/delete')
+      postJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/blocklist/' + id + '/delete')
       .then(function (data) {
         if (data.ok) row.remove();
         else { alert(BL_I18N.error); btn.disabled = false; }
@@ -186,7 +187,7 @@
     if (!confirm(BL_I18N.confirm_bulk_delete_tpl.replace('__COUNT__', checked.length))) return;
     var ids = Array.from(checked).map(function (c) { return parseInt(c.value); });
     bulkBtn.disabled = true;
-    postJson('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/blocklist/bulk-delete', { ids: ids })
+    postJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/blocklist/bulk-delete', { ids: ids })
     .then(function (data) {
       if (data.ok) {
         ids.forEach(function (id) {

--- a/symfony/templates/media/films_collections.html.twig
+++ b/symfony/templates/media/films_collections.html.twig
@@ -178,6 +178,7 @@
 {% block javascripts %}
 <script>
 (function () {
+  var BASE = '{{ app.request.getBasePath() }}';
 
   var COL_I18N = {
     film_count_tpl: {{ 'media.films_collections.modal.film_count'|trans({count: '__COUNT__'})|json_encode|raw }},
@@ -285,7 +286,7 @@
 
     // Load config for selects
     if (hasNonAdded && !colConfigCache) {
-      fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/config', { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+      fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/config', { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
         .then(function(r) { return r.json(); })
         .then(function(cfg) {
           colConfigCache = cfg;
@@ -310,7 +311,7 @@
         btn.disabled = true;
         btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:14px;height:14px;"></span>';
 
-        fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/add', {
+        fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/add', {
           method: 'POST',
           headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
           body: JSON.stringify({
@@ -356,7 +357,7 @@
     var newMonitored = btn.dataset.monitored !== '1';
     btn.disabled = true;
 
-    fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/collections/' + id + '/monitor', {
+    fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/collections/' + id + '/monitor', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
       body: JSON.stringify({ monitored: newMonitored }),
@@ -379,7 +380,7 @@
       var btn = this;
       btn.disabled = true;
 
-      fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/collections/' + id + '/monitor', {
+      fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/collections/' + id + '/monitor', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ monitored: newMonitored }),

--- a/symfony/templates/media/films_collections.html.twig
+++ b/symfony/templates/media/films_collections.html.twig
@@ -178,6 +178,7 @@
 {% block javascripts %}
 <script>
 (function () {
+  var BASE = window.BASE_PATH;
 
   var COL_I18N = {
     film_count_tpl: {{ 'media.films_collections.modal.film_count'|trans({count: '__COUNT__'})|json_encode|raw }},
@@ -285,7 +286,7 @@
 
     // Load config for selects
     if (hasNonAdded && !colConfigCache) {
-      fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/config', { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+      fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/config', { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
         .then(function(r) { return r.json(); })
         .then(function(cfg) {
           colConfigCache = cfg;
@@ -310,7 +311,7 @@
         btn.disabled = true;
         btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:14px;height:14px;"></span>';
 
-        fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/add', {
+        fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/add', {
           method: 'POST',
           headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
           body: JSON.stringify({
@@ -356,7 +357,7 @@
     var newMonitored = btn.dataset.monitored !== '1';
     btn.disabled = true;
 
-    fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/collections/' + id + '/monitor', {
+    fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/collections/' + id + '/monitor', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
       body: JSON.stringify({ monitored: newMonitored }),
@@ -379,7 +380,7 @@
       var btn = this;
       btn.disabled = true;
 
-      fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/collections/' + id + '/monitor', {
+      fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/collections/' + id + '/monitor', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: JSON.stringify({ monitored: newMonitored }),

--- a/symfony/templates/media/films_cutoff.html.twig
+++ b/symfony/templates/media/films_cutoff.html.twig
@@ -111,6 +111,7 @@
 {% block javascripts %}
 <script>
 (function () {
+  var BASE = '{{ app.request.getBasePath() }}';
   var I18N = {
     launched: {{ 'media.films_cutoff.launched'|trans|json_encode|raw }},
     error: {{ 'media.films_cutoff.error'|trans|json_encode|raw }}
@@ -120,7 +121,7 @@
       var id = this.dataset.id;
       btn.disabled = true;
       btn.textContent = '…';
-      fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + id + '/search', {
+      fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + id + '/search', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: '{}',

--- a/symfony/templates/media/films_cutoff.html.twig
+++ b/symfony/templates/media/films_cutoff.html.twig
@@ -111,6 +111,7 @@
 {% block javascripts %}
 <script>
 (function () {
+  var BASE = window.BASE_PATH;
   var I18N = {
     launched: {{ 'media.films_cutoff.launched'|trans|json_encode|raw }},
     error: {{ 'media.films_cutoff.error'|trans|json_encode|raw }}
@@ -120,7 +121,7 @@
       var id = this.dataset.id;
       btn.disabled = true;
       btn.textContent = '…';
-      fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + id + '/search', {
+      fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + id + '/search', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
         body: '{}',

--- a/symfony/templates/media/films_missing.html.twig
+++ b/symfony/templates/media/films_missing.html.twig
@@ -147,6 +147,7 @@
 {% block javascripts %}
 <script>
 (function () {
+  var BASE = '{{ app.request.getBasePath() }}';
   var FM_I18N = {
     searching: {{ 'media.films_missing.searching'|trans|json_encode|raw }},
     download_started: {{ 'media.films_missing.download_started'|trans|json_encode|raw }},
@@ -205,7 +206,7 @@
       statusEl.classList.remove('d-none');
       statusEl.innerHTML = '<span class="text-muted">' + FM_I18N.searching + '</span>';
 
-      postJson('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + id + '/search')
+      postJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + id + '/search')
       .then(function (data) {
         if (!data.ok || !data.cmdId) {
           btn.innerHTML = SVG_FAIL;
@@ -215,7 +216,7 @@
           return;
         }
         var pollTimer = setInterval(function() {
-          getJson('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId).then(function(cmd) {
+          getJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId).then(function(cmd) {
             var st = (cmd.status || '').toLowerCase();
             var msg = cmd.message || '';
             if (st === 'completed') {
@@ -267,7 +268,7 @@
     btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + ids.length + '...';
     showBanner('<span class="spinner-border spinner-border-sm me-2"></span> ' + FM_I18N.searching_for_tpl.replace('__COUNT__', ids.length), 'info');
 
-    postJson('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/recherche-manquants')
+    postJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/recherche-manquants')
     .then(function (data) {
       if (!data.ok || !data.cmdId) {
         showBanner(FM_I18N.launch_error, 'danger');
@@ -282,7 +283,7 @@
       var pollTimer = setInterval(function() {
         pollCount++;
         var elapsed = Math.round(pollCount * 1.5);
-        getJson('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId).then(function(cmd) {
+        getJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId).then(function(cmd) {
           var st = (cmd.status || '').toLowerCase();
           var msg = cmd.message || '';
 
@@ -342,7 +343,7 @@
       var row = btn.closest('tr');
       if (!confirm(FM_I18N.confirm_unmonitor)) return;
       btn.disabled = true;
-      postJson('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + id + '/monitor', { monitored: false })
+      postJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + id + '/monitor', { monitored: false })
       .then(function (data) {
         if (data.ok) {
           row.style.opacity = '0.3';

--- a/symfony/templates/media/films_missing.html.twig
+++ b/symfony/templates/media/films_missing.html.twig
@@ -147,6 +147,7 @@
 {% block javascripts %}
 <script>
 (function () {
+  var BASE = window.BASE_PATH;
   var FM_I18N = {
     searching: {{ 'media.films_missing.searching'|trans|json_encode|raw }},
     download_started: {{ 'media.films_missing.download_started'|trans|json_encode|raw }},
@@ -205,7 +206,7 @@
       statusEl.classList.remove('d-none');
       statusEl.innerHTML = '<span class="text-muted">' + FM_I18N.searching + '</span>';
 
-      postJson('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + id + '/search')
+      postJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + id + '/search')
       .then(function (data) {
         if (!data.ok || !data.cmdId) {
           btn.innerHTML = SVG_FAIL;
@@ -215,7 +216,7 @@
           return;
         }
         var pollTimer = setInterval(function() {
-          getJson('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId).then(function(cmd) {
+          getJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId).then(function(cmd) {
             var st = (cmd.status || '').toLowerCase();
             var msg = cmd.message || '';
             if (st === 'completed') {
@@ -267,7 +268,7 @@
     btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + ids.length + '...';
     showBanner('<span class="spinner-border spinner-border-sm me-2"></span> ' + FM_I18N.searching_for_tpl.replace('__COUNT__', ids.length), 'info');
 
-    postJson('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/recherche-manquants')
+    postJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/recherche-manquants')
     .then(function (data) {
       if (!data.ok || !data.cmdId) {
         showBanner(FM_I18N.launch_error, 'danger');
@@ -282,7 +283,7 @@
       var pollTimer = setInterval(function() {
         pollCount++;
         var elapsed = Math.round(pollCount * 1.5);
-        getJson('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId).then(function(cmd) {
+        getJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/command/' + data.cmdId).then(function(cmd) {
           var st = (cmd.status || '').toLowerCase();
           var msg = cmd.message || '';
 
@@ -342,7 +343,7 @@
       var row = btn.closest('tr');
       if (!confirm(FM_I18N.confirm_unmonitor)) return;
       btn.disabled = true;
-      postJson('/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + id + '/monitor', { monitored: false })
+      postJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_RADARR_SLUG) + '/films/' + id + '/monitor', { monitored: false })
       .then(function (data) {
         if (data.ok) {
           row.style.opacity = '0.3';

--- a/symfony/templates/media/series.html.twig
+++ b/symfony/templates/media/series.html.twig
@@ -986,6 +986,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
 {% block javascripts %}
 <script>
 (function () {
+  var BASE = '{{ app.request.getBasePath() }}';
   /* ══════════════════════════════════════════════════════════════════════════
      i18n injection (FR source of truth ; locale bascule via ?_locale=en)
      ══════════════════════════════════════════════════════════════════════════ */
@@ -1322,7 +1323,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
   // the server (so bulk-filtered actions hit the whole filtered scope, not
   // just the items rendered on the current page).
   function fetchFilteredSeriesIds(extra) {
-    var url = '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/filter/ids?' + currentFilterParams(extra || {});
+    var url = BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/filter/ids?' + currentFilterParams(extra || {});
     return ajaxGet(url).then(function(data) {
       return (data && Array.isArray(data.ids)) ? data.ids : [];
     });
@@ -1459,7 +1460,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     var id = btn.dataset.id;
     var mon = btn.dataset.monitored === '1';
     var newMon = !mon;
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + id + '/monitor', { monitored: newMon }).then(function(data) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + id + '/monitor', { monitored: newMon }).then(function(data) {
       if (data.ok) {
         btn.dataset.monitored = newMon ? '1' : '0';
         var svg = btn.querySelector('svg');
@@ -1528,7 +1529,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
         }
       };
       ids.forEach(function(sid) {
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + sid + '/refresh', {})
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + sid + '/refresh', {})
           .then(finish, finish);
       });
     }).catch(function() {
@@ -1567,7 +1568,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
         }
       };
       ids.forEach(function(sid) {
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + sid + '/search', {})
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + sid + '/search', {})
           .then(finish, finish);
       });
     }).catch(function() {
@@ -1674,7 +1675,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
   });
   function ensureBulkConfig(cb) {
     if (bulkConfigLoaded) { cb(); return; }
-    Promise.all([ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/quality-profiles'), ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/root-folders'), ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/tags-json')]).then(function(r) {
+    Promise.all([ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/quality-profiles'), ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/root-folders'), ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/tags-json')]).then(function(r) {
       bulkConfigLoaded = true;
       var qSel = document.getElementById('bulk-s-quality');
       if (qSel.options.length <= 1) (r[0]||[]).forEach(function(p) { var o = document.createElement('option'); o.value = p.id; o.textContent = p.name; qSel.appendChild(o); });
@@ -1718,7 +1719,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     v = document.getElementById('bulk-s-root').value; if (v) payload.rootFolderPath = v;
     v = document.getElementById('bulk-s-season-folder').value; if (v) payload.seasonFolder = v === 'true';
     var btn = this; btn.disabled = true; btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/bulk/edit', payload).then(function(d) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/bulk/edit', payload).then(function(d) {
       btn.disabled = false; btn.innerHTML = SERIES_I18N.bulk_save;
       closeBulkModal('modal-bulk-edit-series');
       if (d.ok) { showPageBanner(tpl(SERIES_I18N.w_modified_ok_tpl, { COUNT: ids.length }), 'success'); setTimeout(function() { location.reload(); }, 1500); }
@@ -1741,7 +1742,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     var tagIds = []; document.querySelectorAll('.bulk-s-tag-cb:checked').forEach(function(cb) { tagIds.push(parseInt(cb.value)); });
     if (!tagIds.length) return;
     var btn = this; btn.disabled = true; btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/bulk/edit', { seriesIds: ids, tags: tagIds, applyTags: document.getElementById('bulk-s-tags-action').value }).then(function(d) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/bulk/edit', { seriesIds: ids, tags: tagIds, applyTags: document.getElementById('bulk-s-tags-action').value }).then(function(d) {
       btn.disabled = false; btn.innerHTML = SERIES_I18N.bulk_apply;
       closeBulkModal('modal-bulk-tags-series');
       if (d.ok) showPageBanner(tpl(SERIES_I18N.w_tags_ok_tpl, { COUNT: ids.length }), 'success');
@@ -1763,7 +1764,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     var deleteFiles = document.getElementById('bulk-s-delete-files').checked;
     var addExclusion = document.getElementById('bulk-s-delete-exclude').checked;
     var btn = this; btn.disabled = true; btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/bulk/delete', { seriesIds: ids, deleteFiles: deleteFiles, addImportExclusion: addExclusion }).then(function(d) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/bulk/delete', { seriesIds: ids, deleteFiles: deleteFiles, addImportExclusion: addExclusion }).then(function(d) {
       btn.disabled = false; btn.innerHTML = SERIES_I18N.bulk_delete_confirm;
       closeBulkModal('modal-bulk-delete-series');
       if (d.ok) {
@@ -1804,7 +1805,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     ids.forEach(function(sid) {
       var card = grid.querySelector('[data-id="' + sid + '"]');
       var title = card ? (card.getAttribute('title') || '?') : '?';
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + sid + '/rename').then(function(proposals) {
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + sid + '/rename').then(function(proposals) {
         loaded++;
         if (proposals && proposals.length) {
           renameSeriesIds.push(sid);
@@ -1843,7 +1844,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     var btn = this; btn.disabled = true; btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
     var done = 0;
     renameSeriesIds.forEach(function(sid) {
-      ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + sid + '/rename', { fileIds: [] }).then(function() {
+      ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + sid + '/rename', { fileIds: [] }).then(function() {
         done++;
         if (done >= renameSeriesIds.length) {
           btn.innerHTML = SERIES_I18N.bulk_rename_go;
@@ -1979,7 +1980,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
       btn.addEventListener('click', function() {
         if (!confirm(SERIES_I18N.queue_confirm_delete)) return;
         btn.disabled = true;
-        fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue/' + btn.dataset.id + '/delete', {
+        fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue/' + btn.dataset.id + '/delete', {
           method: 'POST',
           headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
           body: JSON.stringify({ removeFromClient: true, blocklist: false }),
@@ -1994,7 +1995,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     queueTbody.querySelectorAll('.btn-queue-grab').forEach(function(btn) {
       btn.addEventListener('click', function() {
         btn.disabled = true;
-        fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue/' + btn.dataset.id + '/grab', {
+        fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue/' + btn.dataset.id + '/grab', {
           method: 'POST',
           headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
           body: '{}'
@@ -2061,7 +2062,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
           cleanBtn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:12px;height:12px;"></span> ' + SERIES_I18N.queue_cleaning;
           var done = 0;
           staleItems.forEach(function(w) {
-            fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue/' + w.id + '/delete', {
+            fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue/' + w.id + '/delete', {
               method: 'POST',
               headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
               body: JSON.stringify({ removeFromClient: true, blocklist: false }),
@@ -2085,7 +2086,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
           var items = realBlocked.map(function(w) {
             return { path: w.outputPath || '', downloadId: w.downloadId || '' };
           }).filter(function(it) { return it.path !== '' || it.downloadId !== ''; });
-          fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue/import', {
+          fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue/import', {
             method: 'POST',
             headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
             body: JSON.stringify({ items: items }),
@@ -2128,7 +2129,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
   }
 
   function refreshQueue() {
-    fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue', { headers: {'X-Requested-With': 'XMLHttpRequest'} })
+    fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue', { headers: {'X-Requested-With': 'XMLHttpRequest'} })
     .then(function(r) { return r.json(); })
     .then(function(items) { renderQueue(items); });
   }
@@ -2139,7 +2140,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
   setInterval(refreshQueue, 2000);
   // RefreshMonitoredDownloads every 8s (tells Sonarr to check qBittorrent)
   setInterval(function() {
-    fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue/refresh', {
+    fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue/refresh', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}',
@@ -2236,8 +2237,8 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     epContainer.innerHTML = '<div class="text-center text-muted py-4"><span class="spinner-border spinner-border-sm me-1"></span> ' + esc(SERIES_I18N.d_loading_episodes) + '</div>';
 
     Promise.all([
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/episodes'),
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/files')
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/episodes'),
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/files')
     ]).then(function(results) {
       var episodes = results[0] || [];
       var allFiles = results[1] || [];
@@ -2366,7 +2367,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
           var epId = parseInt(btn.dataset.epId);
           btn.disabled = true;
           btn.innerHTML = SVG_SPIN_SM;
-          postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/search', { episodeIds: [epId] }, function(data) {
+          postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/search', { episodeIds: [epId] }, function(data) {
             if (data.cmdId) {
               pollCmd(data.cmdId, SERIES_I18N.d_search_cmd_episode, function(success) {
                 btn.innerHTML = success ? SVG_OK_SM : SVG_SEARCH_SM;
@@ -2386,7 +2387,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
           e.stopPropagation();
           var mon = btn.dataset.monitored !== '1';
           btn.disabled = true;
-          postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/season/monitor', {
+          postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/season/monitor', {
             seriesId: parseInt(btn.dataset.seriesId),
             seasonNumber: parseInt(btn.dataset.season),
             monitored: mon,
@@ -2435,12 +2436,12 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
 
             // Send all monitor changes
             epIds.forEach(function(epId) {
-              postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/' + epId + '/monitor', { monitored: mon }, function() {});
+              postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/' + epId + '/monitor', { monitored: mon }, function() {});
             });
           } else {
             // Single click
             btn.disabled = true;
-            postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/' + btn.dataset.epId + '/monitor', { monitored: mon }, function() {
+            postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/' + btn.dataset.epId + '/monitor', { monitored: mon }, function() {
               btn.dataset.monitored = mon ? '1' : '0';
               btn.innerHTML = mon ? SVG_MONITOR_ON : SVG_MONITOR_OFF;
               btn.title = mon ? SERIES_I18N.d_unmonitor : SERIES_I18N.d_monitor;
@@ -2485,7 +2486,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
           content.innerHTML     = '';
           document.getElementById('ep-filemanager-feedback').style.display = 'none';
 
-          ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/history')
+          ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/history')
           .then(function(allHistory) {
             btn.innerHTML = SVG_HISTORY;
             loading.style.display = 'none';
@@ -2544,7 +2545,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
           e.stopPropagation();
           btn.disabled = true;
           btn.innerHTML = SVG_SPIN_SM;
-          postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + btn.dataset.seriesId + '/season/' + btn.dataset.season + '/search', {}, function(data) {
+          postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + btn.dataset.seriesId + '/season/' + btn.dataset.season + '/search', {}, function(data) {
             if (data.cmdId) {
               pollCmd(data.cmdId, tpl(SERIES_I18N.d_search_season_tpl, { N: btn.dataset.season }), function(success) {
                 btn.innerHTML = success ? SVG_OK_SM : SVG_SEARCH_SM;
@@ -2582,7 +2583,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
           document.getElementById('ep-releases-title').textContent = tpl(SERIES_I18N.d_releases_season_tpl, { N: sn });
 
           searchInProgress = true;
-          ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/season/' + sn + '/releases')
+          ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/season/' + sn + '/releases')
           .then(function(releases) {
             searchInProgress = false;
             btn.disabled = false;
@@ -2619,7 +2620,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
           content.innerHTML = '';
           document.getElementById('ep-filemanager-feedback').style.display = 'none';
 
-          ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/rename').then(function(proposals) {
+          ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/rename').then(function(proposals) {
             btn.disabled = false;
             btn.innerHTML = RENAME_ICON;
             loading.style.display = 'none';
@@ -2658,10 +2659,10 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
               var goBtn = this;
               goBtn.disabled = true;
               goBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + SERIES_I18N.d_rename_in_progress;
-              ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/rename', { fileIds: fileIds }).then(function(data) {
+              ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/rename', { fileIds: fileIds }).then(function(data) {
                 if (data.ok && data.cmdId) {
                   var pollRename = setInterval(function() {
-                    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/' + data.cmdId).then(function(cmd) {
+                    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/' + data.cmdId).then(function(cmd) {
                       var st = (cmd.status || '').toLowerCase();
                       if (st === 'completed') {
                         clearInterval(pollRename);
@@ -2696,7 +2697,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
           if (!confirm(SERIES_I18N.d_confirm_delete_file)) return;
           btn.disabled = true;
           btn.innerHTML = SVG_SPIN_SM;
-          postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/file/' + btn.dataset.fileId + '/delete', {}, function() {
+          postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/file/' + btn.dataset.fileId + '/delete', {}, function() {
             showBanner(SERIES_I18N.d_file_deleted, 'success');
             setTimeout(function() { hideBanner(); loadEpisodes(); }, 1500);
           }, function() {
@@ -2792,7 +2793,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
   // Tout analyser + RSS Sync
   document.getElementById('btn-refresh-all-series').addEventListener('click', function() {
     var btn = this; btn.disabled = true;
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/refresh-all', {}).then(function(d) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/refresh-all', {}).then(function(d) {
       btn.disabled = false;
       if (d.ok && d.cmdId) {
         pollCmd(d.cmdId, SERIES_I18N.w_refresh_label, function() {});
@@ -2804,7 +2805,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
 
   document.getElementById('btn-rss-sync-series').addEventListener('click', function() {
     var btn = this; btn.disabled = true;
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/rss-sync', {}).then(function(d) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/rss-sync', {}).then(function(d) {
       btn.disabled = false;
       if (d.ok && d.cmdId) {
         pollCmd(d.cmdId, SERIES_I18N.w_rss_label, function() {});
@@ -2819,7 +2820,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     if (bannerLocked) return;
     var el = document.getElementById('sonarr-warnings-banner');
     if (!el) return;
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/warnings').then(function(warnings) {
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/warnings').then(function(warnings) {
       if (!warnings || !warnings.length) { el.innerHTML = ''; return; }
       el.innerHTML = '<div class="alert alert-warning mb-3"><div class="d-flex align-items-center"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="me-2 flex-shrink-0"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg><div>' + warnings.map(function(w) { return '<div>' + w + '</div>'; }).join('') + '</div></div></div>';
     }).catch(function(){});
@@ -2829,7 +2830,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
 
   // Check for active commands on page load (only user-initiated ones)
   var POLL_COMMANDS = {'SeriesSearch':1,'SeasonSearch':1,'EpisodeSearch':1,'RenameFiles':1,'MissingEpisodeSearch':1};
-  ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/commands/active').then(function(cmds) {
+  ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/commands/active').then(function(cmds) {
     if (!cmds || !cmds.length) return;
     cmds.forEach(function(cmd) {
       var name = cmd.name || '';
@@ -2857,7 +2858,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     var timer = setInterval(function() {
       pollCount++;
       var elapsed = pollCount * 2;
-      fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/' + cmdId, { headers: {'X-Requested-With':'XMLHttpRequest'} })
+      fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/' + cmdId, { headers: {'X-Requested-With':'XMLHttpRequest'} })
       .then(function(r) { return r.json(); })
       .then(function(cmd) {
         var st = (cmd.status || '').toLowerCase();
@@ -2914,7 +2915,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     var btn = this;
     btn.disabled = true;
     btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + SERIES_I18N.d_refresh_in_progress;
-    postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/refresh', {}, function(data) {
+    postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/refresh', {}, function(data) {
       if (data.cmdId) {
         pollCmd(data.cmdId, SERIES_I18N.w_refresh_label, function(success) {
           btn.disabled = false;
@@ -2936,7 +2937,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     var btn = this;
     btn.disabled = true;
     btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + SERIES_I18N.d_search_in_progress;
-    postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/search', {}, function (data) {
+    postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/search', {}, function (data) {
       if (data.cmdId) {
         var label = SERIES_I18N.d_search_series;
         pollCmd(data.cmdId, label, function() {
@@ -2972,7 +2973,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     content.innerHTML     = '';
     document.getElementById('ep-filemanager-feedback').style.display = 'none';
 
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/history')
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/history')
     .then(function(history) {
       btn.disabled = false;
       btn.innerHTML = HISTORY_ICON + ' ' + SERIES_I18N.d_history;
@@ -3027,9 +3028,9 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     content.innerHTML     = '';
     document.getElementById('ep-filemanager-feedback').style.display = 'none';
 
-    var pFiles = ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/files');
-    var pQuals = qualityDefsCache ? Promise.resolve(qualityDefsCache) : ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/quality-definitions');
-    var pEpisodes = ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/episodes');
+    var pFiles = ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/files');
+    var pQuals = qualityDefsCache ? Promise.resolve(qualityDefsCache) : ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/quality-definitions');
+    var pEpisodes = ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/episodes');
 
     Promise.all([pFiles, pQuals, pEpisodes]).then(function(results) {
       btn.disabled = false;
@@ -3090,10 +3091,10 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     document.getElementById('ep-filemanager-feedback').style.display = 'none';
 
     Promise.all([
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/info'),
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/quality-profiles'),
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/root-folders'),
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/tags-json')
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/info'),
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/quality-profiles'),
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/root-folders'),
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/tags-json')
     ]).then(function(results) {
       btn.disabled = false;
       btn.innerHTML = EDIT_ICON + ' ' + SERIES_I18N.d_modify;
@@ -3201,7 +3202,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
         var val = input.value.trim();
         if (!val) return;
         input.value = '';
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/tags-json', { label: val }).then(function(data) {
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/tags-json', { label: val }).then(function(data) {
           if (data.ok && data.tag) {
             var container = document.getElementById('edit-tags-container');
             var lbl = document.createElement('label');
@@ -3226,7 +3227,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
       function browsePath(path) {
         browser.style.display = '';
         browser.innerHTML = '<div class="p-2 text-muted small"><span class="spinner-border spinner-border-sm me-1"></span> ' + esc(SERIES_I18N.d_edit_browse_loading) + '</div>';
-        ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/filesystem?path=' + encodeURIComponent(path))
+        ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/filesystem?path=' + encodeURIComponent(path))
         .then(function(data) {
           var dirs = data.directories || [];
           var parentPath = data.parent || '/';
@@ -3271,7 +3272,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
         if (!confirm(tpl(SERIES_I18N.d_confirm_move_tpl, { PATH: newPath }))) return;
         var updateBtn = this;
         updateBtn.disabled = true;
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/edit', { path: newPath })
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/edit', { path: newPath })
         .then(function(data) {
           updateBtn.disabled = false;
           if (data.ok) {
@@ -3295,7 +3296,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
         var title = s.title || SERIES_I18N.d_confirm_delete_series_default;
         if (!confirm(tpl(SERIES_I18N.d_confirm_delete_series_tpl, { TITLE: title }))) return;
         var deleteFiles = confirm(SERIES_I18N.d_confirm_delete_files);
-        postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/delete', { deleteFiles: deleteFiles }, function() {
+        postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/delete', { deleteFiles: deleteFiles }, function() {
           closeFileOverlay();
           var card = grid.querySelector('[data-id="' + currentId + '"]');
           if (card) card.remove();
@@ -3321,7 +3322,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
           path: document.getElementById('edit-path').value,
           tags: selectedTags
         };
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/edit', payload)
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/edit', payload)
         .then(function(data) {
           saveBtn.disabled = false;
           saveBtn.innerHTML = SERIES_I18N.d_edit_save;
@@ -3381,7 +3382,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     var newMonitored = !currentMonitored;
     this.disabled    = true;
     var btn          = this;
-    postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/monitor', { monitored: newMonitored }, function (data) {
+    postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/monitor', { monitored: newMonitored }, function (data) {
       currentMonitored = data.monitored;
       btn.disabled     = false;
       refreshSerieMonitorBtn();
@@ -3407,7 +3408,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     document.getElementById('ep-filemanager-feedback').style.display = 'none';
     document.getElementById('ep-filemanager-title').textContent = SERIES_I18N.d_rename_files;
 
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/rename')
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/rename')
     .then(function(proposals) {
       loading.style.display = 'none';
 
@@ -3472,7 +3473,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
         execBtn.disabled = true;
         execBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" style="width:12px;height:12px;"></span> ' + SERIES_I18N.d_rename_in_progress;
 
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/rename', { fileIds: fileIds })
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/rename', { fileIds: fileIds })
         .then(function(data) {
           if (!data.ok || !data.cmdId) {
             execBtn.disabled = false;
@@ -3483,7 +3484,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
 
           // Poll
           var timer = setInterval(function() {
-            ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/' + data.cmdId)
+            ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/' + data.cmdId)
             .then(function(cmd) {
               var st = (cmd.status || '').toLowerCase();
               if (st === 'completed') {
@@ -3523,7 +3524,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     var deleteFiles = confirm(SERIES_I18N.d_confirm_delete_files);
     var btn = this;
     btn.disabled = true;
-    postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/delete', { deleteFiles: deleteFiles }, function () {
+    postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/delete', { deleteFiles: deleteFiles }, function () {
       // Supprimer la card de la grille
       var card = grid.querySelector('[data-id="' + currentId + '"]');
       if (card) card.remove();
@@ -3586,7 +3587,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     document.getElementById('ep-releases-title').textContent = tpl(SERIES_I18N.d_releases_episode_tpl, { LBL: (epLabel || SERIES_I18N.d_col_episode) });
 
     searchInProgress = true;
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/' + epId + '/releases')
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/' + epId + '/releases')
     .then(function(releases) {
       searchInProgress = false;
       loading.style.display = 'none';
@@ -3693,7 +3694,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     if (!btn) return;
     btn.disabled = true;
     btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:.7rem;height:.7rem"></span>';
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/release/grab', { guid: btn.dataset.guid, indexerId: parseInt(btn.dataset.indexer) })
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/release/grab', { guid: btn.dataset.guid, indexerId: parseInt(btn.dataset.indexer) })
     .then(function(data) {
       if (data.ok) {
         btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>';
@@ -3763,7 +3764,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
   });
 
   function refreshSeriesCard(seriesId) {
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/info').then(function(s) {
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/info').then(function(s) {
       if (!s || !s.id) return;
       var card = grid.querySelector('[data-id="' + seriesId + '"]');
       if (!card) return;
@@ -3900,11 +3901,11 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     document.getElementById('ep-filemanager-feedback').style.display = 'none';
     document.getElementById('ep-filemanager-title').textContent = tpl(SERIES_I18N.d_filemanager_season_title_tpl, { N: seasonNumber });
 
-    var pFiles = ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/files');
+    var pFiles = ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/files');
     var pQuals = qualityDefsCache
       ? Promise.resolve(qualityDefsCache)
-      : ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/quality-definitions');
-    var pEpisodes = ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/episodes');
+      : ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/quality-definitions');
+    var pEpisodes = ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/episodes');
 
     Promise.all([pFiles, pQuals, pEpisodes]).then(function(results) {
       var allFiles = results[0] || [];
@@ -4562,7 +4563,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
         // Only send bulk-update if non-episode fields changed
         var hasNonEpChanges = Object.keys(payload).length > 1; // more than just fileId
         if (hasNonEpChanges) {
-          promises.push(ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/files/bulk-update', payload));
+          promises.push(ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/files/bulk-update', payload));
         }
         // Send reassign if episode changed
         if (epChanged && curEpVal) {
@@ -4574,7 +4575,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
             if ((ep.episodeNumber || 0) === targetEpNum) targetEpId = ep.id;
           });
           if (targetEpId) {
-            promises.push(ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/file/' + fileId + '/reassign', {
+            promises.push(ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/file/' + fileId + '/reassign', {
               seriesId: parseInt(currentId),
               episodeIds: [targetEpId]
             }));
@@ -4636,7 +4637,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
         if (!confirm(SERIES_I18N.d_confirm_delete_file)) return;
         btn.disabled = true;
         btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:12px;height:12px;"></span>';
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/file/' + btn.dataset.fileId + '/delete')
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/file/' + btn.dataset.fileId + '/delete')
         .then(function(data) {
           if (data && data.ok) {
             showFmFeedback(SERIES_I18N.d_file_deleted, 'success');
@@ -4702,9 +4703,9 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     if (!addConfigLoaded) {
       addConfigLoaded = true;
       Promise.all([
-        ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/quality-profiles'),
-        ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/root-folders'),
-        ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/tags-json')
+        ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/quality-profiles'),
+        ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/root-folders'),
+        ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/tags-json')
       ]).then(function(results) {
         var profiles = results[0] || [];
         var roots = results[1] || [];
@@ -4746,7 +4747,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     addSearchTimer = setTimeout(function() {
       document.getElementById('add-serie-loading').style.display = '';
       document.getElementById('add-serie-results').innerHTML = '';
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/lookup?term=' + encodeURIComponent(q)).then(function(results) {
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/lookup?term=' + encodeURIComponent(q)).then(function(results) {
         document.getElementById('add-serie-loading').style.display = 'none';
         var container = document.getElementById('add-serie-results');
         container.innerHTML = '';
@@ -4807,7 +4808,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     document.querySelectorAll('.add-tag-cb:checked').forEach(function(cb) {
       selectedTags.push(parseInt(cb.value));
     });
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/add', {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/add', {
       tvdbId: parseInt(document.getElementById('add-serie-tvdbid').value),
       rootFolderPath: document.getElementById('add-serie-root').value,
       qualityProfileId: parseInt(document.getElementById('add-serie-quality').value),

--- a/symfony/templates/media/series.html.twig
+++ b/symfony/templates/media/series.html.twig
@@ -986,6 +986,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
 {% block javascripts %}
 <script>
 (function () {
+  var BASE = window.BASE_PATH;
   /* ══════════════════════════════════════════════════════════════════════════
      i18n injection (FR source of truth ; locale bascule via ?_locale=en)
      ══════════════════════════════════════════════════════════════════════════ */
@@ -1322,7 +1323,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
   // the server (so bulk-filtered actions hit the whole filtered scope, not
   // just the items rendered on the current page).
   function fetchFilteredSeriesIds(extra) {
-    var url = '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/filter/ids?' + currentFilterParams(extra || {});
+    var url = BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/filter/ids?' + currentFilterParams(extra || {});
     return ajaxGet(url).then(function(data) {
       return (data && Array.isArray(data.ids)) ? data.ids : [];
     });
@@ -1459,7 +1460,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     var id = btn.dataset.id;
     var mon = btn.dataset.monitored === '1';
     var newMon = !mon;
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + id + '/monitor', { monitored: newMon }).then(function(data) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + id + '/monitor', { monitored: newMon }).then(function(data) {
       if (data.ok) {
         btn.dataset.monitored = newMon ? '1' : '0';
         var svg = btn.querySelector('svg');
@@ -1528,7 +1529,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
         }
       };
       ids.forEach(function(sid) {
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + sid + '/refresh', {})
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + sid + '/refresh', {})
           .then(finish, finish);
       });
     }).catch(function() {
@@ -1567,7 +1568,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
         }
       };
       ids.forEach(function(sid) {
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + sid + '/search', {})
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + sid + '/search', {})
           .then(finish, finish);
       });
     }).catch(function() {
@@ -1674,7 +1675,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
   });
   function ensureBulkConfig(cb) {
     if (bulkConfigLoaded) { cb(); return; }
-    Promise.all([ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/quality-profiles'), ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/root-folders'), ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/tags-json')]).then(function(r) {
+    Promise.all([ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/quality-profiles'), ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/root-folders'), ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/tags-json')]).then(function(r) {
       bulkConfigLoaded = true;
       var qSel = document.getElementById('bulk-s-quality');
       if (qSel.options.length <= 1) (r[0]||[]).forEach(function(p) { var o = document.createElement('option'); o.value = p.id; o.textContent = p.name; qSel.appendChild(o); });
@@ -1718,7 +1719,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     v = document.getElementById('bulk-s-root').value; if (v) payload.rootFolderPath = v;
     v = document.getElementById('bulk-s-season-folder').value; if (v) payload.seasonFolder = v === 'true';
     var btn = this; btn.disabled = true; btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/bulk/edit', payload).then(function(d) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/bulk/edit', payload).then(function(d) {
       btn.disabled = false; btn.innerHTML = SERIES_I18N.bulk_save;
       closeBulkModal('modal-bulk-edit-series');
       if (d.ok) { showPageBanner(tpl(SERIES_I18N.w_modified_ok_tpl, { COUNT: ids.length }), 'success'); setTimeout(function() { location.reload(); }, 1500); }
@@ -1741,7 +1742,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     var tagIds = []; document.querySelectorAll('.bulk-s-tag-cb:checked').forEach(function(cb) { tagIds.push(parseInt(cb.value)); });
     if (!tagIds.length) return;
     var btn = this; btn.disabled = true; btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/bulk/edit', { seriesIds: ids, tags: tagIds, applyTags: document.getElementById('bulk-s-tags-action').value }).then(function(d) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/bulk/edit', { seriesIds: ids, tags: tagIds, applyTags: document.getElementById('bulk-s-tags-action').value }).then(function(d) {
       btn.disabled = false; btn.innerHTML = SERIES_I18N.bulk_apply;
       closeBulkModal('modal-bulk-tags-series');
       if (d.ok) showPageBanner(tpl(SERIES_I18N.w_tags_ok_tpl, { COUNT: ids.length }), 'success');
@@ -1763,7 +1764,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     var deleteFiles = document.getElementById('bulk-s-delete-files').checked;
     var addExclusion = document.getElementById('bulk-s-delete-exclude').checked;
     var btn = this; btn.disabled = true; btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/bulk/delete', { seriesIds: ids, deleteFiles: deleteFiles, addImportExclusion: addExclusion }).then(function(d) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/bulk/delete', { seriesIds: ids, deleteFiles: deleteFiles, addImportExclusion: addExclusion }).then(function(d) {
       btn.disabled = false; btn.innerHTML = SERIES_I18N.bulk_delete_confirm;
       closeBulkModal('modal-bulk-delete-series');
       if (d.ok) {
@@ -1804,7 +1805,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     ids.forEach(function(sid) {
       var card = grid.querySelector('[data-id="' + sid + '"]');
       var title = card ? (card.getAttribute('title') || '?') : '?';
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + sid + '/rename').then(function(proposals) {
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + sid + '/rename').then(function(proposals) {
         loaded++;
         if (proposals && proposals.length) {
           renameSeriesIds.push(sid);
@@ -1843,7 +1844,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     var btn = this; btn.disabled = true; btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span>';
     var done = 0;
     renameSeriesIds.forEach(function(sid) {
-      ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + sid + '/rename', { fileIds: [] }).then(function() {
+      ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + sid + '/rename', { fileIds: [] }).then(function() {
         done++;
         if (done >= renameSeriesIds.length) {
           btn.innerHTML = SERIES_I18N.bulk_rename_go;
@@ -1979,7 +1980,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
       btn.addEventListener('click', function() {
         if (!confirm(SERIES_I18N.queue_confirm_delete)) return;
         btn.disabled = true;
-        fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue/' + btn.dataset.id + '/delete', {
+        fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue/' + btn.dataset.id + '/delete', {
           method: 'POST',
           headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
           body: JSON.stringify({ removeFromClient: true, blocklist: false }),
@@ -1994,7 +1995,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     queueTbody.querySelectorAll('.btn-queue-grab').forEach(function(btn) {
       btn.addEventListener('click', function() {
         btn.disabled = true;
-        fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue/' + btn.dataset.id + '/grab', {
+        fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue/' + btn.dataset.id + '/grab', {
           method: 'POST',
           headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
           body: '{}'
@@ -2061,7 +2062,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
           cleanBtn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:12px;height:12px;"></span> ' + SERIES_I18N.queue_cleaning;
           var done = 0;
           staleItems.forEach(function(w) {
-            fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue/' + w.id + '/delete', {
+            fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue/' + w.id + '/delete', {
               method: 'POST',
               headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
               body: JSON.stringify({ removeFromClient: true, blocklist: false }),
@@ -2085,7 +2086,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
           var items = realBlocked.map(function(w) {
             return { path: w.outputPath || '', downloadId: w.downloadId || '' };
           }).filter(function(it) { return it.path !== '' || it.downloadId !== ''; });
-          fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue/import', {
+          fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue/import', {
             method: 'POST',
             headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
             body: JSON.stringify({ items: items }),
@@ -2128,7 +2129,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
   }
 
   function refreshQueue() {
-    fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue', { headers: {'X-Requested-With': 'XMLHttpRequest'} })
+    fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue', { headers: {'X-Requested-With': 'XMLHttpRequest'} })
     .then(function(r) { return r.json(); })
     .then(function(items) { renderQueue(items); });
   }
@@ -2139,7 +2140,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
   setInterval(refreshQueue, 2000);
   // RefreshMonitoredDownloads every 8s (tells Sonarr to check qBittorrent)
   setInterval(function() {
-    fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue/refresh', {
+    fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/queue/refresh', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}',
@@ -2236,8 +2237,8 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     epContainer.innerHTML = '<div class="text-center text-muted py-4"><span class="spinner-border spinner-border-sm me-1"></span> ' + esc(SERIES_I18N.d_loading_episodes) + '</div>';
 
     Promise.all([
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/episodes'),
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/files')
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/episodes'),
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/files')
     ]).then(function(results) {
       var episodes = results[0] || [];
       var allFiles = results[1] || [];
@@ -2366,7 +2367,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
           var epId = parseInt(btn.dataset.epId);
           btn.disabled = true;
           btn.innerHTML = SVG_SPIN_SM;
-          postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/search', { episodeIds: [epId] }, function(data) {
+          postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/search', { episodeIds: [epId] }, function(data) {
             if (data.cmdId) {
               pollCmd(data.cmdId, SERIES_I18N.d_search_cmd_episode, function(success) {
                 btn.innerHTML = success ? SVG_OK_SM : SVG_SEARCH_SM;
@@ -2386,7 +2387,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
           e.stopPropagation();
           var mon = btn.dataset.monitored !== '1';
           btn.disabled = true;
-          postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/season/monitor', {
+          postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/season/monitor', {
             seriesId: parseInt(btn.dataset.seriesId),
             seasonNumber: parseInt(btn.dataset.season),
             monitored: mon,
@@ -2435,12 +2436,12 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
 
             // Send all monitor changes
             epIds.forEach(function(epId) {
-              postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/' + epId + '/monitor', { monitored: mon }, function() {});
+              postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/' + epId + '/monitor', { monitored: mon }, function() {});
             });
           } else {
             // Single click
             btn.disabled = true;
-            postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/' + btn.dataset.epId + '/monitor', { monitored: mon }, function() {
+            postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/' + btn.dataset.epId + '/monitor', { monitored: mon }, function() {
               btn.dataset.monitored = mon ? '1' : '0';
               btn.innerHTML = mon ? SVG_MONITOR_ON : SVG_MONITOR_OFF;
               btn.title = mon ? SERIES_I18N.d_unmonitor : SERIES_I18N.d_monitor;
@@ -2485,7 +2486,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
           content.innerHTML     = '';
           document.getElementById('ep-filemanager-feedback').style.display = 'none';
 
-          ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/history')
+          ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/history')
           .then(function(allHistory) {
             btn.innerHTML = SVG_HISTORY;
             loading.style.display = 'none';
@@ -2544,7 +2545,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
           e.stopPropagation();
           btn.disabled = true;
           btn.innerHTML = SVG_SPIN_SM;
-          postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + btn.dataset.seriesId + '/season/' + btn.dataset.season + '/search', {}, function(data) {
+          postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + btn.dataset.seriesId + '/season/' + btn.dataset.season + '/search', {}, function(data) {
             if (data.cmdId) {
               pollCmd(data.cmdId, tpl(SERIES_I18N.d_search_season_tpl, { N: btn.dataset.season }), function(success) {
                 btn.innerHTML = success ? SVG_OK_SM : SVG_SEARCH_SM;
@@ -2582,7 +2583,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
           document.getElementById('ep-releases-title').textContent = tpl(SERIES_I18N.d_releases_season_tpl, { N: sn });
 
           searchInProgress = true;
-          ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/season/' + sn + '/releases')
+          ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/season/' + sn + '/releases')
           .then(function(releases) {
             searchInProgress = false;
             btn.disabled = false;
@@ -2619,7 +2620,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
           content.innerHTML = '';
           document.getElementById('ep-filemanager-feedback').style.display = 'none';
 
-          ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/rename').then(function(proposals) {
+          ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/rename').then(function(proposals) {
             btn.disabled = false;
             btn.innerHTML = RENAME_ICON;
             loading.style.display = 'none';
@@ -2658,10 +2659,10 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
               var goBtn = this;
               goBtn.disabled = true;
               goBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + SERIES_I18N.d_rename_in_progress;
-              ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/rename', { fileIds: fileIds }).then(function(data) {
+              ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/rename', { fileIds: fileIds }).then(function(data) {
                 if (data.ok && data.cmdId) {
                   var pollRename = setInterval(function() {
-                    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/' + data.cmdId).then(function(cmd) {
+                    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/' + data.cmdId).then(function(cmd) {
                       var st = (cmd.status || '').toLowerCase();
                       if (st === 'completed') {
                         clearInterval(pollRename);
@@ -2696,7 +2697,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
           if (!confirm(SERIES_I18N.d_confirm_delete_file)) return;
           btn.disabled = true;
           btn.innerHTML = SVG_SPIN_SM;
-          postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/file/' + btn.dataset.fileId + '/delete', {}, function() {
+          postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/file/' + btn.dataset.fileId + '/delete', {}, function() {
             showBanner(SERIES_I18N.d_file_deleted, 'success');
             setTimeout(function() { hideBanner(); loadEpisodes(); }, 1500);
           }, function() {
@@ -2792,7 +2793,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
   // Tout analyser + RSS Sync
   document.getElementById('btn-refresh-all-series').addEventListener('click', function() {
     var btn = this; btn.disabled = true;
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/refresh-all', {}).then(function(d) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/refresh-all', {}).then(function(d) {
       btn.disabled = false;
       if (d.ok && d.cmdId) {
         pollCmd(d.cmdId, SERIES_I18N.w_refresh_label, function() {});
@@ -2804,7 +2805,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
 
   document.getElementById('btn-rss-sync-series').addEventListener('click', function() {
     var btn = this; btn.disabled = true;
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/rss-sync', {}).then(function(d) {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/rss-sync', {}).then(function(d) {
       btn.disabled = false;
       if (d.ok && d.cmdId) {
         pollCmd(d.cmdId, SERIES_I18N.w_rss_label, function() {});
@@ -2819,7 +2820,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     if (bannerLocked) return;
     var el = document.getElementById('sonarr-warnings-banner');
     if (!el) return;
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/warnings').then(function(warnings) {
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/warnings').then(function(warnings) {
       if (!warnings || !warnings.length) { el.innerHTML = ''; return; }
       el.innerHTML = '<div class="alert alert-warning mb-3"><div class="d-flex align-items-center"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="me-2 flex-shrink-0"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg><div>' + warnings.map(function(w) { return '<div>' + w + '</div>'; }).join('') + '</div></div></div>';
     }).catch(function(){});
@@ -2829,7 +2830,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
 
   // Check for active commands on page load (only user-initiated ones)
   var POLL_COMMANDS = {'SeriesSearch':1,'SeasonSearch':1,'EpisodeSearch':1,'RenameFiles':1,'MissingEpisodeSearch':1};
-  ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/commands/active').then(function(cmds) {
+  ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/commands/active').then(function(cmds) {
     if (!cmds || !cmds.length) return;
     cmds.forEach(function(cmd) {
       var name = cmd.name || '';
@@ -2857,7 +2858,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     var timer = setInterval(function() {
       pollCount++;
       var elapsed = pollCount * 2;
-      fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/' + cmdId, { headers: {'X-Requested-With':'XMLHttpRequest'} })
+      fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/' + cmdId, { headers: {'X-Requested-With':'XMLHttpRequest'} })
       .then(function(r) { return r.json(); })
       .then(function(cmd) {
         var st = (cmd.status || '').toLowerCase();
@@ -2914,7 +2915,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     var btn = this;
     btn.disabled = true;
     btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + SERIES_I18N.d_refresh_in_progress;
-    postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/refresh', {}, function(data) {
+    postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/refresh', {}, function(data) {
       if (data.cmdId) {
         pollCmd(data.cmdId, SERIES_I18N.w_refresh_label, function(success) {
           btn.disabled = false;
@@ -2936,7 +2937,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     var btn = this;
     btn.disabled = true;
     btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + SERIES_I18N.d_search_in_progress;
-    postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/search', {}, function (data) {
+    postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/search', {}, function (data) {
       if (data.cmdId) {
         var label = SERIES_I18N.d_search_series;
         pollCmd(data.cmdId, label, function() {
@@ -2972,7 +2973,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     content.innerHTML     = '';
     document.getElementById('ep-filemanager-feedback').style.display = 'none';
 
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/history')
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/history')
     .then(function(history) {
       btn.disabled = false;
       btn.innerHTML = HISTORY_ICON + ' ' + SERIES_I18N.d_history;
@@ -3027,9 +3028,9 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     content.innerHTML     = '';
     document.getElementById('ep-filemanager-feedback').style.display = 'none';
 
-    var pFiles = ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/files');
-    var pQuals = qualityDefsCache ? Promise.resolve(qualityDefsCache) : ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/quality-definitions');
-    var pEpisodes = ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/episodes');
+    var pFiles = ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/files');
+    var pQuals = qualityDefsCache ? Promise.resolve(qualityDefsCache) : ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/quality-definitions');
+    var pEpisodes = ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/episodes');
 
     Promise.all([pFiles, pQuals, pEpisodes]).then(function(results) {
       btn.disabled = false;
@@ -3090,10 +3091,10 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     document.getElementById('ep-filemanager-feedback').style.display = 'none';
 
     Promise.all([
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/info'),
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/quality-profiles'),
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/root-folders'),
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/tags-json')
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/info'),
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/quality-profiles'),
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/root-folders'),
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/tags-json')
     ]).then(function(results) {
       btn.disabled = false;
       btn.innerHTML = EDIT_ICON + ' ' + SERIES_I18N.d_modify;
@@ -3201,7 +3202,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
         var val = input.value.trim();
         if (!val) return;
         input.value = '';
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/tags-json', { label: val }).then(function(data) {
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/tags-json', { label: val }).then(function(data) {
           if (data.ok && data.tag) {
             var container = document.getElementById('edit-tags-container');
             var lbl = document.createElement('label');
@@ -3226,7 +3227,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
       function browsePath(path) {
         browser.style.display = '';
         browser.innerHTML = '<div class="p-2 text-muted small"><span class="spinner-border spinner-border-sm me-1"></span> ' + esc(SERIES_I18N.d_edit_browse_loading) + '</div>';
-        ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/filesystem?path=' + encodeURIComponent(path))
+        ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/filesystem?path=' + encodeURIComponent(path))
         .then(function(data) {
           var dirs = data.directories || [];
           var parentPath = data.parent || '/';
@@ -3271,7 +3272,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
         if (!confirm(tpl(SERIES_I18N.d_confirm_move_tpl, { PATH: newPath }))) return;
         var updateBtn = this;
         updateBtn.disabled = true;
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/edit', { path: newPath })
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/edit', { path: newPath })
         .then(function(data) {
           updateBtn.disabled = false;
           if (data.ok) {
@@ -3295,7 +3296,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
         var title = s.title || SERIES_I18N.d_confirm_delete_series_default;
         if (!confirm(tpl(SERIES_I18N.d_confirm_delete_series_tpl, { TITLE: title }))) return;
         var deleteFiles = confirm(SERIES_I18N.d_confirm_delete_files);
-        postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/delete', { deleteFiles: deleteFiles }, function() {
+        postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/delete', { deleteFiles: deleteFiles }, function() {
           closeFileOverlay();
           var card = grid.querySelector('[data-id="' + currentId + '"]');
           if (card) card.remove();
@@ -3321,7 +3322,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
           path: document.getElementById('edit-path').value,
           tags: selectedTags
         };
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/edit', payload)
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/edit', payload)
         .then(function(data) {
           saveBtn.disabled = false;
           saveBtn.innerHTML = SERIES_I18N.d_edit_save;
@@ -3381,7 +3382,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     var newMonitored = !currentMonitored;
     this.disabled    = true;
     var btn          = this;
-    postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/monitor', { monitored: newMonitored }, function (data) {
+    postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/monitor', { monitored: newMonitored }, function (data) {
       currentMonitored = data.monitored;
       btn.disabled     = false;
       refreshSerieMonitorBtn();
@@ -3407,7 +3408,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     document.getElementById('ep-filemanager-feedback').style.display = 'none';
     document.getElementById('ep-filemanager-title').textContent = SERIES_I18N.d_rename_files;
 
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/rename')
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/rename')
     .then(function(proposals) {
       loading.style.display = 'none';
 
@@ -3472,7 +3473,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
         execBtn.disabled = true;
         execBtn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" style="width:12px;height:12px;"></span> ' + SERIES_I18N.d_rename_in_progress;
 
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/rename', { fileIds: fileIds })
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/rename', { fileIds: fileIds })
         .then(function(data) {
           if (!data.ok || !data.cmdId) {
             execBtn.disabled = false;
@@ -3483,7 +3484,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
 
           // Poll
           var timer = setInterval(function() {
-            ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/' + data.cmdId)
+            ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/' + data.cmdId)
             .then(function(cmd) {
               var st = (cmd.status || '').toLowerCase();
               if (st === 'completed') {
@@ -3523,7 +3524,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     var deleteFiles = confirm(SERIES_I18N.d_confirm_delete_files);
     var btn = this;
     btn.disabled = true;
-    postAction('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/delete', { deleteFiles: deleteFiles }, function () {
+    postAction(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + currentId + '/delete', { deleteFiles: deleteFiles }, function () {
       // Supprimer la card de la grille
       var card = grid.querySelector('[data-id="' + currentId + '"]');
       if (card) card.remove();
@@ -3586,7 +3587,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     document.getElementById('ep-releases-title').textContent = tpl(SERIES_I18N.d_releases_episode_tpl, { LBL: (epLabel || SERIES_I18N.d_col_episode) });
 
     searchInProgress = true;
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/' + epId + '/releases')
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/' + epId + '/releases')
     .then(function(releases) {
       searchInProgress = false;
       loading.style.display = 'none';
@@ -3693,7 +3694,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     if (!btn) return;
     btn.disabled = true;
     btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:.7rem;height:.7rem"></span>';
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/release/grab', { guid: btn.dataset.guid, indexerId: parseInt(btn.dataset.indexer) })
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/release/grab', { guid: btn.dataset.guid, indexerId: parseInt(btn.dataset.indexer) })
     .then(function(data) {
       if (data.ok) {
         btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>';
@@ -3763,7 +3764,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
   });
 
   function refreshSeriesCard(seriesId) {
-    ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/info').then(function(s) {
+    ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/info').then(function(s) {
       if (!s || !s.id) return;
       var card = grid.querySelector('[data-id="' + seriesId + '"]');
       if (!card) return;
@@ -3900,11 +3901,11 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     document.getElementById('ep-filemanager-feedback').style.display = 'none';
     document.getElementById('ep-filemanager-title').textContent = tpl(SERIES_I18N.d_filemanager_season_title_tpl, { N: seasonNumber });
 
-    var pFiles = ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/files');
+    var pFiles = ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/files');
     var pQuals = qualityDefsCache
       ? Promise.resolve(qualityDefsCache)
-      : ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/quality-definitions');
-    var pEpisodes = ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/episodes');
+      : ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/quality-definitions');
+    var pEpisodes = ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/episodes');
 
     Promise.all([pFiles, pQuals, pEpisodes]).then(function(results) {
       var allFiles = results[0] || [];
@@ -4562,7 +4563,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
         // Only send bulk-update if non-episode fields changed
         var hasNonEpChanges = Object.keys(payload).length > 1; // more than just fileId
         if (hasNonEpChanges) {
-          promises.push(ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/files/bulk-update', payload));
+          promises.push(ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/files/bulk-update', payload));
         }
         // Send reassign if episode changed
         if (epChanged && curEpVal) {
@@ -4574,7 +4575,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
             if ((ep.episodeNumber || 0) === targetEpNum) targetEpId = ep.id;
           });
           if (targetEpId) {
-            promises.push(ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/file/' + fileId + '/reassign', {
+            promises.push(ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/file/' + fileId + '/reassign', {
               seriesId: parseInt(currentId),
               episodeIds: [targetEpId]
             }));
@@ -4636,7 +4637,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
         if (!confirm(SERIES_I18N.d_confirm_delete_file)) return;
         btn.disabled = true;
         btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:12px;height:12px;"></span>';
-        ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/file/' + btn.dataset.fileId + '/delete')
+        ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/file/' + btn.dataset.fileId + '/delete')
         .then(function(data) {
           if (data && data.ok) {
             showFmFeedback(SERIES_I18N.d_file_deleted, 'success');
@@ -4702,9 +4703,9 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     if (!addConfigLoaded) {
       addConfigLoaded = true;
       Promise.all([
-        ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/quality-profiles'),
-        ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/root-folders'),
-        ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/tags-json')
+        ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/quality-profiles'),
+        ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/root-folders'),
+        ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/sonarr/tags-json')
       ]).then(function(results) {
         var profiles = results[0] || [];
         var roots = results[1] || [];
@@ -4746,7 +4747,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     addSearchTimer = setTimeout(function() {
       document.getElementById('add-serie-loading').style.display = '';
       document.getElementById('add-serie-results').innerHTML = '';
-      ajaxGet('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/lookup?term=' + encodeURIComponent(q)).then(function(results) {
+      ajaxGet(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/lookup?term=' + encodeURIComponent(q)).then(function(results) {
         document.getElementById('add-serie-loading').style.display = 'none';
         var container = document.getElementById('add-serie-results');
         container.innerHTML = '';
@@ -4807,7 +4808,7 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
     document.querySelectorAll('.add-tag-cb:checked').forEach(function(cb) {
       selectedTags.push(parseInt(cb.value));
     });
-    ajaxPost('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/add', {
+    ajaxPost(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/add', {
       tvdbId: parseInt(document.getElementById('add-serie-tvdbid').value),
       rootFolderPath: document.getElementById('add-serie-root').value,
       qualityProfileId: parseInt(document.getElementById('add-serie-quality').value),

--- a/symfony/templates/media/series_blocklist.html.twig
+++ b/symfony/templates/media/series_blocklist.html.twig
@@ -80,6 +80,7 @@
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = '{{ app.request.getBasePath() }}';
   var SB_I18N = {
     bulk_delete_tpl: {{ 'media.series_blocklist.bulk_delete_tpl'|trans({count: '__COUNT__'})|json_encode|raw }},
     confirm_delete: {{ 'media.series_blocklist.confirm_delete'|trans|json_encode|raw }},
@@ -116,7 +117,7 @@
     document.querySelectorAll('.blocklist-cb:checked').forEach(function(cb) { ids.push(parseInt(cb.dataset.id)); });
     if (!ids.length || !confirm(tpl(SB_I18N.confirm_bulk_delete_tpl, { COUNT: ids.length }))) return;
     bulkBtn.disabled = true;
-    fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/blocklist/bulk-delete', {
+    fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/blocklist/bulk-delete', {
       method: 'POST',
       headers: {'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
       body: JSON.stringify({ids: ids})
@@ -133,7 +134,7 @@
     btn.addEventListener('click', function() {
       if (!confirm(SB_I18N.confirm_delete)) return;
       btn.disabled = true;
-      fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/blocklist/' + btn.dataset.id + '/delete', {
+      fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/blocklist/' + btn.dataset.id + '/delete', {
         method: 'POST',
         headers: {'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
         body: '{}'

--- a/symfony/templates/media/series_blocklist.html.twig
+++ b/symfony/templates/media/series_blocklist.html.twig
@@ -80,6 +80,7 @@
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = window.BASE_PATH;
   var SB_I18N = {
     bulk_delete_tpl: {{ 'media.series_blocklist.bulk_delete_tpl'|trans({count: '__COUNT__'})|json_encode|raw }},
     confirm_delete: {{ 'media.series_blocklist.confirm_delete'|trans|json_encode|raw }},
@@ -116,7 +117,7 @@
     document.querySelectorAll('.blocklist-cb:checked').forEach(function(cb) { ids.push(parseInt(cb.dataset.id)); });
     if (!ids.length || !confirm(tpl(SB_I18N.confirm_bulk_delete_tpl, { COUNT: ids.length }))) return;
     bulkBtn.disabled = true;
-    fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/blocklist/bulk-delete', {
+    fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/blocklist/bulk-delete', {
       method: 'POST',
       headers: {'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
       body: JSON.stringify({ids: ids})
@@ -133,7 +134,7 @@
     btn.addEventListener('click', function() {
       if (!confirm(SB_I18N.confirm_delete)) return;
       btn.disabled = true;
-      fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/blocklist/' + btn.dataset.id + '/delete', {
+      fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/blocklist/' + btn.dataset.id + '/delete', {
         method: 'POST',
         headers: {'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
         body: '{}'

--- a/symfony/templates/media/series_detail.html.twig
+++ b/symfony/templates/media/series_detail.html.twig
@@ -219,6 +219,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = '{{ app.request.getBasePath() }}';
   var SD_I18N = {
     search_launched: {{ 'media.series_detail.feedback.search_launched'|trans|json_encode|raw }},
     search_season_launched_tpl: {{ 'media.series_detail.feedback.search_season_launched_tpl'|trans({n: '__N__'})|json_encode|raw }},
@@ -276,7 +277,7 @@
   document.getElementById('btn-search-serie').addEventListener('click', function() {
     var btn = this;
     btn.disabled = true;
-    postJson('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + btn.dataset.id + '/search', {})
+    postJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + btn.dataset.id + '/search', {})
     .then(function(data) {
       btn.disabled = false;
       showFeedback(data.ok ? SD_I18N.search_launched : SD_I18N.error, data.ok ? 'success' : 'danger');
@@ -288,7 +289,7 @@
     var btn = this;
     var newMon = btn.dataset.monitored !== '1';
     btn.disabled = true;
-    postJson('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + btn.dataset.id + '/monitor', { monitored: newMon })
+    postJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + btn.dataset.id + '/monitor', { monitored: newMon })
     .then(function(data) {
       btn.disabled = false;
       if (data.ok) {
@@ -306,7 +307,7 @@
       var season = btn.dataset.season;
       btn.disabled = true;
       btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:14px;height:14px;"></span>';
-      postJson('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/season/' + season + '/search', {})
+      postJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/season/' + season + '/search', {})
       .then(function(data) {
         btn.disabled = false;
         btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>';
@@ -322,7 +323,7 @@
       if (!epId) return;
       btn.disabled = true;
       btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:12px;height:12px;"></span>';
-      postJson('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/search', { episodeIds: [epId] })
+      postJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/search', { episodeIds: [epId] })
       .then(function(data) {
         btn.disabled = false;
         if (data.ok) {

--- a/symfony/templates/media/series_detail.html.twig
+++ b/symfony/templates/media/series_detail.html.twig
@@ -219,6 +219,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = window.BASE_PATH;
   var SD_I18N = {
     search_launched: {{ 'media.series_detail.feedback.search_launched'|trans|json_encode|raw }},
     search_season_launched_tpl: {{ 'media.series_detail.feedback.search_season_launched_tpl'|trans({n: '__N__'})|json_encode|raw }},
@@ -276,7 +277,7 @@
   document.getElementById('btn-search-serie').addEventListener('click', function() {
     var btn = this;
     btn.disabled = true;
-    postJson('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + btn.dataset.id + '/search', {})
+    postJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + btn.dataset.id + '/search', {})
     .then(function(data) {
       btn.disabled = false;
       showFeedback(data.ok ? SD_I18N.search_launched : SD_I18N.error, data.ok ? 'success' : 'danger');
@@ -288,7 +289,7 @@
     var btn = this;
     var newMon = btn.dataset.monitored !== '1';
     btn.disabled = true;
-    postJson('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + btn.dataset.id + '/monitor', { monitored: newMon })
+    postJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + btn.dataset.id + '/monitor', { monitored: newMon })
     .then(function(data) {
       btn.disabled = false;
       if (data.ok) {
@@ -306,7 +307,7 @@
       var season = btn.dataset.season;
       btn.disabled = true;
       btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:14px;height:14px;"></span>';
-      postJson('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/season/' + season + '/search', {})
+      postJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/' + seriesId + '/season/' + season + '/search', {})
       .then(function(data) {
         btn.disabled = false;
         btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>';
@@ -322,7 +323,7 @@
       if (!epId) return;
       btn.disabled = true;
       btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:12px;height:12px;"></span>';
-      postJson('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/search', { episodeIds: [epId] })
+      postJson(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/search', { episodeIds: [epId] })
       .then(function(data) {
         btn.disabled = false;
         if (data.ok) {

--- a/symfony/templates/media/series_missing.html.twig
+++ b/symfony/templates/media/series_missing.html.twig
@@ -84,6 +84,7 @@
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = '{{ app.request.getBasePath() }}';
   var SM_I18N = {
     searching_all: {{ 'media.series_missing.searching_all'|trans|json_encode|raw }},
     search_all: {{ 'media.series_missing.search_all'|trans|json_encode|raw }},
@@ -104,7 +105,7 @@
     btn.addEventListener('click', function() {
       btn.disabled = true;
       btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:12px;height:12px;"></span>';
-      fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/search', {
+      fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/search', {
         method: 'POST',
         headers: {'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
         body: JSON.stringify({episodeIds: [parseInt(btn.dataset.epId)]})
@@ -120,7 +121,7 @@
       btnAll.disabled = true;
       btnAll.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + SM_I18N.searching_all;
       showBanner('<span class="spinner-border spinner-border-sm me-2"></span> ' + SM_I18N.searching_label, 'info');
-      fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/missing-search', {
+      fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/missing-search', {
         method: 'POST',
         headers: {'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
         body: '{}'

--- a/symfony/templates/media/series_missing.html.twig
+++ b/symfony/templates/media/series_missing.html.twig
@@ -84,6 +84,7 @@
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = window.BASE_PATH;
   var SM_I18N = {
     searching_all: {{ 'media.series_missing.searching_all'|trans|json_encode|raw }},
     search_all: {{ 'media.series_missing.search_all'|trans|json_encode|raw }},
@@ -104,7 +105,7 @@
     btn.addEventListener('click', function() {
       btn.disabled = true;
       btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:12px;height:12px;"></span>';
-      fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/search', {
+      fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/episode/search', {
         method: 'POST',
         headers: {'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
         body: JSON.stringify({episodeIds: [parseInt(btn.dataset.epId)]})
@@ -120,7 +121,7 @@
       btnAll.disabled = true;
       btnAll.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + SM_I18N.searching_all;
       showBanner('<span class="spinner-border spinner-border-sm me-2"></span> ' + SM_I18N.searching_label, 'info');
-      fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/missing-search', {
+      fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/command/missing-search', {
         method: 'POST',
         headers: {'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
         body: '{}'

--- a/symfony/templates/prowlarr/apps.html.twig
+++ b/symfony/templates/prowlarr/apps.html.twig
@@ -194,12 +194,13 @@
 {% block javascripts %}
 <script>
 (function () {
-    var SCHEMA_URL = '/prowlarr/application/schema';
-    var GET_URL = '/prowlarr/application/{id}';
-    var ADD_URL = '/prowlarr/application/add';
-    var UPDATE_URL = '/prowlarr/application/{id}/update';
-    var DELETE_URL = '/prowlarr/application/{id}/delete';
-    var TEST_URL = '/prowlarr/application/test';
+    var BASE = '{{ app.request.getBasePath() }}';
+    var SCHEMA_URL = BASE + '/prowlarr/application/schema';
+    var GET_URL = BASE + '/prowlarr/application/{id}';
+    var ADD_URL = BASE + '/prowlarr/application/add';
+    var UPDATE_URL = BASE + '/prowlarr/application/{id}/update';
+    var DELETE_URL = BASE + '/prowlarr/application/{id}/delete';
+    var TEST_URL = BASE + '/prowlarr/application/test';
 
     var _I18N = {
         name: {{ 'prowlarr.common.name'|trans|json_encode|raw }},
@@ -305,7 +306,7 @@
     // Sync Profiles
     var profilesData = [];
     function loadProfiles() {
-        fetch('/prowlarr/app-profiles').then(function(r){return r.json();}).then(function(profiles) {
+        fetch(BASE + '/prowlarr/app-profiles').then(function(r){return r.json();}).then(function(profiles) {
             profilesData = profiles;
             var body = document.getElementById('sync-profiles-body');
             if (!profiles.length) { body.innerHTML = '<div class="text-center text-secondary small">' + esc(_I18N.profilesEmpty) + '</div>'; return; }
@@ -359,7 +360,7 @@
             enableInteractiveSearch: document.getElementById('profile-interactive').checked,
             minimumSeeders: parseInt(document.getElementById('profile-seeders').value) || 1,
         };
-        var url = editingProfileId ? '/prowlarr/app-profile/' + editingProfileId + '/update' : '/prowlarr/app-profile/add';
+        var url = editingProfileId ? BASE + '/prowlarr/app-profile/' + editingProfileId + '/update' : BASE + '/prowlarr/app-profile/add';
         if (editingProfileId) payload.id = editingProfileId;
         btn.disabled = true; btn.textContent = _I18N.saving;
         fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
@@ -374,7 +375,7 @@
 
     document.getElementById('profile-delete').addEventListener('click', function() {
         if (!editingProfileId || !confirm(_I18N.confirmDeleteProfile)) return;
-        fetch('/prowlarr/app-profile/' + editingProfileId + '/delete', { method: 'POST' })
+        fetch(BASE + '/prowlarr/app-profile/' + editingProfileId + '/delete', { method: 'POST' })
             .then(function(r) { return r.json(); })
             .then(function(d) { if (d.ok) { closeModal('pw-modal-profile'); loadProfiles(); } });
     });

--- a/symfony/templates/prowlarr/apps.html.twig
+++ b/symfony/templates/prowlarr/apps.html.twig
@@ -194,12 +194,13 @@
 {% block javascripts %}
 <script>
 (function () {
-    var SCHEMA_URL = '/prowlarr/application/schema';
-    var GET_URL = '/prowlarr/application/{id}';
-    var ADD_URL = '/prowlarr/application/add';
-    var UPDATE_URL = '/prowlarr/application/{id}/update';
-    var DELETE_URL = '/prowlarr/application/{id}/delete';
-    var TEST_URL = '/prowlarr/application/test';
+    var BASE = window.BASE_PATH;
+    var SCHEMA_URL = BASE + '/prowlarr/application/schema';
+    var GET_URL = BASE + '/prowlarr/application/{id}';
+    var ADD_URL = BASE + '/prowlarr/application/add';
+    var UPDATE_URL = BASE + '/prowlarr/application/{id}/update';
+    var DELETE_URL = BASE + '/prowlarr/application/{id}/delete';
+    var TEST_URL = BASE + '/prowlarr/application/test';
 
     var _I18N = {
         name: {{ 'prowlarr.common.name'|trans|json_encode|raw }},
@@ -305,7 +306,7 @@
     // Sync Profiles
     var profilesData = [];
     function loadProfiles() {
-        fetch('/prowlarr/app-profiles').then(function(r){return r.json();}).then(function(profiles) {
+        fetch(BASE + '/prowlarr/app-profiles').then(function(r){return r.json();}).then(function(profiles) {
             profilesData = profiles;
             var body = document.getElementById('sync-profiles-body');
             if (!profiles.length) { body.innerHTML = '<div class="text-center text-secondary small">' + esc(_I18N.profilesEmpty) + '</div>'; return; }
@@ -359,7 +360,7 @@
             enableInteractiveSearch: document.getElementById('profile-interactive').checked,
             minimumSeeders: parseInt(document.getElementById('profile-seeders').value) || 1,
         };
-        var url = editingProfileId ? '/prowlarr/app-profile/' + editingProfileId + '/update' : '/prowlarr/app-profile/add';
+        var url = editingProfileId ? BASE + '/prowlarr/app-profile/' + editingProfileId + '/update' : BASE + '/prowlarr/app-profile/add';
         if (editingProfileId) payload.id = editingProfileId;
         btn.disabled = true; btn.textContent = _I18N.saving;
         fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
@@ -374,7 +375,7 @@
 
     document.getElementById('profile-delete').addEventListener('click', function() {
         if (!editingProfileId || !confirm(_I18N.confirmDeleteProfile)) return;
-        fetch('/prowlarr/app-profile/' + editingProfileId + '/delete', { method: 'POST' })
+        fetch(BASE + '/prowlarr/app-profile/' + editingProfileId + '/delete', { method: 'POST' })
             .then(function(r) { return r.json(); })
             .then(function(d) { if (d.ok) { closeModal('pw-modal-profile'); loadProfiles(); } });
     });

--- a/symfony/templates/prowlarr/backups.html.twig
+++ b/symfony/templates/prowlarr/backups.html.twig
@@ -114,6 +114,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = '{{ app.request.getBasePath() }}';
 var _I18N = {
     starting: {{ 'prowlarr.backups.create_starting'|trans|json_encode|raw }},
     done: {{ 'prowlarr.backups.create_done'|trans|json_encode|raw }},
@@ -166,7 +167,7 @@ document.querySelectorAll('.btn-backup-delete').forEach(function(btn) {
         if (!confirm(_I18N.confirmDeleteTpl.replace('__NAME__', name))) return;
         btn.disabled = true;
 
-        fetch('/prowlarr/sauvegardes/' + btn.dataset.id + '/supprimer', {
+        fetch(BASE + '/prowlarr/sauvegardes/' + btn.dataset.id + '/supprimer', {
             method: 'POST',
             headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
             body: '{}',

--- a/symfony/templates/prowlarr/backups.html.twig
+++ b/symfony/templates/prowlarr/backups.html.twig
@@ -114,6 +114,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = window.BASE_PATH;
 var _I18N = {
     starting: {{ 'prowlarr.backups.create_starting'|trans|json_encode|raw }},
     done: {{ 'prowlarr.backups.create_done'|trans|json_encode|raw }},
@@ -166,7 +167,7 @@ document.querySelectorAll('.btn-backup-delete').forEach(function(btn) {
         if (!confirm(_I18N.confirmDeleteTpl.replace('__NAME__', name))) return;
         btn.disabled = true;
 
-        fetch('/prowlarr/sauvegardes/' + btn.dataset.id + '/supprimer', {
+        fetch(BASE + '/prowlarr/sauvegardes/' + btn.dataset.id + '/supprimer', {
             method: 'POST',
             headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
             body: '{}',

--- a/symfony/templates/prowlarr/download_clients.html.twig
+++ b/symfony/templates/prowlarr/download_clients.html.twig
@@ -132,12 +132,13 @@
 {% block javascripts %}
 <script>
 (function () {
-    var SCHEMA_URL = '/prowlarr/downloadclient/schema';
-    var GET_URL = '/prowlarr/downloadclient/{id}';
-    var ADD_URL = '/prowlarr/downloadclient/add';
-    var UPDATE_URL = '/prowlarr/downloadclient/{id}/update';
-    var DELETE_URL = '/prowlarr/downloadclient/{id}/delete';
-    var TEST_URL = '/prowlarr/downloadclient/test';
+    var BASE = '{{ app.request.getBasePath() }}';
+    var SCHEMA_URL = BASE + '/prowlarr/downloadclient/schema';
+    var GET_URL = BASE + '/prowlarr/downloadclient/{id}';
+    var ADD_URL = BASE + '/prowlarr/downloadclient/add';
+    var UPDATE_URL = BASE + '/prowlarr/downloadclient/{id}/update';
+    var DELETE_URL = BASE + '/prowlarr/downloadclient/{id}/delete';
+    var TEST_URL = BASE + '/prowlarr/downloadclient/test';
 
     var _I18N = {
         name: {{ 'prowlarr.common.name'|trans|json_encode|raw }},

--- a/symfony/templates/prowlarr/download_clients.html.twig
+++ b/symfony/templates/prowlarr/download_clients.html.twig
@@ -132,12 +132,13 @@
 {% block javascripts %}
 <script>
 (function () {
-    var SCHEMA_URL = '/prowlarr/downloadclient/schema';
-    var GET_URL = '/prowlarr/downloadclient/{id}';
-    var ADD_URL = '/prowlarr/downloadclient/add';
-    var UPDATE_URL = '/prowlarr/downloadclient/{id}/update';
-    var DELETE_URL = '/prowlarr/downloadclient/{id}/delete';
-    var TEST_URL = '/prowlarr/downloadclient/test';
+    var BASE = window.BASE_PATH;
+    var SCHEMA_URL = BASE + '/prowlarr/downloadclient/schema';
+    var GET_URL = BASE + '/prowlarr/downloadclient/{id}';
+    var ADD_URL = BASE + '/prowlarr/downloadclient/add';
+    var UPDATE_URL = BASE + '/prowlarr/downloadclient/{id}/update';
+    var DELETE_URL = BASE + '/prowlarr/downloadclient/{id}/delete';
+    var TEST_URL = BASE + '/prowlarr/downloadclient/test';
 
     var _I18N = {
         name: {{ 'prowlarr.common.name'|trans|json_encode|raw }},

--- a/symfony/templates/prowlarr/general.html.twig
+++ b/symfony/templates/prowlarr/general.html.twig
@@ -178,6 +178,7 @@
 {% block javascripts %}
 <script>
 (function () {
+    var BASE = '{{ app.request.getBasePath() }}';
     var _I18N = {
         saveBtn: {{ 'prowlarr.general.save_btn'|trans|json_encode|raw }},
         saving: {{ 'prowlarr.common.saving'|trans|json_encode|raw }},
@@ -227,7 +228,7 @@
         btn.disabled = true;
         btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + _I18N.saving;
 
-        fetch('/prowlarr/general/save', {
+        fetch(BASE + '/prowlarr/general/save', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload)

--- a/symfony/templates/prowlarr/general.html.twig
+++ b/symfony/templates/prowlarr/general.html.twig
@@ -178,6 +178,7 @@
 {% block javascripts %}
 <script>
 (function () {
+    var BASE = window.BASE_PATH;
     var _I18N = {
         saveBtn: {{ 'prowlarr.general.save_btn'|trans|json_encode|raw }},
         saving: {{ 'prowlarr.common.saving'|trans|json_encode|raw }},
@@ -227,7 +228,7 @@
         btn.disabled = true;
         btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + _I18N.saving;
 
-        fetch('/prowlarr/general/save', {
+        fetch(BASE + '/prowlarr/general/save', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload)

--- a/symfony/templates/prowlarr/index.html.twig
+++ b/symfony/templates/prowlarr/index.html.twig
@@ -408,6 +408,7 @@
 {% block javascripts %}
 <script>
 (function () {
+    var BASE = '{{ app.request.getBasePath() }}';
     var _I18N = {
         name: {{ 'prowlarr.common.name'|trans|json_encode|raw }},
         appProfile: {{ 'prowlarr.index.field_app_profile'|trans|json_encode|raw }},
@@ -540,7 +541,7 @@
             h += '</div>';
             // Charger app profiles
             if (!appProfilesCache) {
-                fetch('/prowlarr/app-profiles').then(function(r){return r.json();}).then(function(profiles) {
+                fetch(BASE + '/prowlarr/app-profiles').then(function(r){return r.json();}).then(function(profiles) {
                     appProfilesCache = profiles;
                     fillAppProfileSelect(topLevel.appProfileId);
                 });
@@ -599,7 +600,7 @@
     function loadAndRenderTags(currentTags) {
         selectedTags = currentTags || [];
         if (!tagsCache) {
-            fetch('/prowlarr/tags').then(function(r) { return r.json(); }).then(function(tags) {
+            fetch(BASE + '/prowlarr/tags').then(function(r) { return r.json(); }).then(function(tags) {
                 tagsCache = tags;
                 renderTagsUI();
             });
@@ -653,7 +654,7 @@
         var label = (input.value || '').trim();
         if (!label) return;
         input.disabled = true;
-        fetch('/prowlarr/tag/create', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ label: label }) })
+        fetch(BASE + '/prowlarr/tag/create', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ label: label }) })
             .then(function(r) { return r.json(); })
             .then(function(d) {
                 input.disabled = false;
@@ -706,7 +707,7 @@
     document.querySelectorAll('[data-toggle-id]').forEach(function (btn) {
         btn.addEventListener('click', function () {
             btn.disabled = true; btn.textContent = '…';
-            fetch('/prowlarr/indexer/' + btn.dataset.toggleId + '/toggle', { method: 'POST' })
+            fetch(BASE + '/prowlarr/indexer/' + btn.dataset.toggleId + '/toggle', { method: 'POST' })
                 .then(function (r) { return r.json(); })
                 .then(function (d) { btn.disabled = false; if (d.ok) { btn.classList.toggle('is-on', d.enabled); btn.classList.toggle('is-off', !d.enabled); btn.textContent = d.enabled ? 'ON' : 'OFF'; } });
         });
@@ -716,7 +717,7 @@
     document.querySelectorAll('[data-delete-id]').forEach(function (btn) {
         btn.addEventListener('click', function () {
             if (!confirm(_I18N.confirmDeleteIndexerTpl.replace('__NAME__', btn.dataset.deleteName))) return;
-            fetch('/prowlarr/indexer/' + btn.dataset.deleteId + '/delete', { method: 'POST' })
+            fetch(BASE + '/prowlarr/indexer/' + btn.dataset.deleteId + '/delete', { method: 'POST' })
                 .then(function (r) { return r.json(); })
                 .then(function (d) { if (d.ok) { var row = btn.closest('tr'); if (row) row.remove(); } });
         });
@@ -729,10 +730,10 @@
             var orig = btn.innerHTML;
             btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:.7rem;height:.7rem;"></span>';
             btn.disabled = true;
-            fetch('/prowlarr/indexer/' + id, { method: 'GET' })
+            fetch(BASE + '/prowlarr/indexer/' + id, { method: 'GET' })
                 .then(function (r) { return r.json(); })
                 .then(function (raw) {
-                    return fetch('/prowlarr/indexer/test', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(cleanPayload(raw)) });
+                    return fetch(BASE + '/prowlarr/indexer/test', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(cleanPayload(raw)) });
                 })
                 .then(function (r) { return r.json(); })
                 .then(function (d) {
@@ -749,7 +750,7 @@
         var btn = this;
         btn.disabled = true;
         btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:.7rem;height:.7rem;"></span> ' + _I18N.testAllInProgress;
-        fetch('/prowlarr/indexer/testall', { method: 'POST' })
+        fetch(BASE + '/prowlarr/indexer/testall', { method: 'POST' })
             .then(function (r) { return r.json(); })
             .then(function (d) {
                 btn.disabled = false;
@@ -782,7 +783,7 @@
     document.getElementById('btn-sync-indexers').addEventListener('click', function () {
         var btn = this; btn.disabled = true;
         btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:.7rem;height:.7rem;"></span> ' + _I18N.syncInProgress;
-        fetch('/prowlarr/command', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: 'ApplicationIndexerSync' }) })
+        fetch(BASE + '/prowlarr/command', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: 'ApplicationIndexerSync' }) })
             .then(function (r) { return r.json(); })
             .then(function (d) {
                 if (!d.ok) { btn.disabled = false; btn.innerHTML = syncOrigHtml; return; }
@@ -790,7 +791,7 @@
                 if (!cmdId) { btn.disabled = false; btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2" class="me-1"><path d="M5 12l5 5l10-10"/></svg> ' + _I18N.syncDone; setTimeout(function(){btn.innerHTML=syncOrigHtml;},2000); return; }
                 // Poll command status
                 var poll = setInterval(function () {
-                    fetch('/prowlarr/command/' + cmdId)
+                    fetch(BASE + '/prowlarr/command/' + cmdId)
                         .then(function(r){return r.json();})
                         .then(function(s) {
                             if (!s || s.status === 'completed') {
@@ -821,7 +822,7 @@
         var q = searchInput.value.trim();
         if (q.length < 2) return;
         searchLoading.style.display = ''; searchResults.innerHTML = ''; searchBtn.disabled = true;
-        fetch('/prowlarr/search?q=' + encodeURIComponent(q))
+        fetch(BASE + '/prowlarr/search?q=' + encodeURIComponent(q))
             .then(function (r) { return r.json(); })
             .then(function (items) {
                 searchLoading.style.display = 'none'; searchBtn.disabled = false;
@@ -863,7 +864,7 @@
         openModal('modal-add-indexer');
         if (!schemaCache) {
             document.getElementById('add-idx-list').innerHTML = '<div class="col-12 text-center py-3"><div class="spinner-border spinner-border-sm text-secondary"></div></div>';
-            fetch('/prowlarr/indexer/schema').then(function (r) { return r.json(); }).then(function (data) { schemaCache = data; populateFilterDropdowns(); renderSchemaList(getAddFilters()); });
+            fetch(BASE + '/prowlarr/indexer/schema').then(function (r) { return r.json(); }).then(function (data) { schemaCache = data; populateFilterDropdowns(); renderSchemaList(getAddFilters()); });
         } else { renderSchemaList(getAddFilters()); }
     });
 
@@ -987,7 +988,7 @@
         var payload = collectTopLevel(document.getElementById('add-idx-fields'), selectedSchema);
         payload.fields = collectFields(document.getElementById('add-idx-fields'), selectedSchema.fields || []);
         btn.disabled = true; btn.textContent = _I18N.testing;
-        fetch('/prowlarr/indexer/test', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(cleanPayload(payload)) })
+        fetch(BASE + '/prowlarr/indexer/test', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(cleanPayload(payload)) })
             .then(function (r) { return r.json(); })
             .then(function (d) {
                 btn.disabled = false; btn.textContent = _I18N.test;
@@ -1001,7 +1002,7 @@
         var payload = collectTopLevel(document.getElementById('add-idx-fields'), selectedSchema);
         payload.fields = collectFields(document.getElementById('add-idx-fields'), selectedSchema.fields || []);
         btn.disabled = true; btn.textContent = _I18N.adding;
-        fetch('/prowlarr/indexer/add', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(cleanPayload(payload)) })
+        fetch(BASE + '/prowlarr/indexer/add', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(cleanPayload(payload)) })
             .then(function (r) { return r.json(); })
             .then(function (d) {
                 btn.disabled = false; btn.textContent = _I18N.add;
@@ -1043,7 +1044,7 @@
             document.getElementById('edit-idx-fields').innerHTML = '<div class="text-center py-3"><div class="spinner-border spinner-border-sm text-secondary"></div></div>';
             document.getElementById('edit-idx-result').className = 'mt-2 alert d-none';
             openModal('modal-edit-indexer');
-            fetch('/prowlarr/indexer/' + id)
+            fetch(BASE + '/prowlarr/indexer/' + id)
                 .then(function (r) { return r.json(); })
                 .then(function (raw) {
                     editRaw = raw;
@@ -1065,7 +1066,7 @@
         var payload = collectTopLevel(document.getElementById('edit-idx-fields'), editRaw);
         payload.fields = collectFields(document.getElementById('edit-idx-fields'), editRaw.fields || []);
         btn.disabled = true; btn.textContent = _I18N.testing;
-        fetch('/prowlarr/indexer/test', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(cleanPayload(payload)) })
+        fetch(BASE + '/prowlarr/indexer/test', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(cleanPayload(payload)) })
             .then(function (r) { return r.json(); })
             .then(function (d) {
                 btn.disabled = false; btn.textContent = _I18N.test;
@@ -1079,7 +1080,7 @@
         var payload = collectTopLevel(document.getElementById('edit-idx-fields'), editRaw);
         payload.fields = collectFields(document.getElementById('edit-idx-fields'), editRaw.fields || []);
         btn.disabled = true; btn.textContent = _I18N.saving;
-        fetch('/prowlarr/indexer/' + editRaw.id + '/update', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(cleanPayload(payload)) })
+        fetch(BASE + '/prowlarr/indexer/' + editRaw.id + '/update', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(cleanPayload(payload)) })
             .then(function (r) { return r.json(); })
             .then(function (d) {
                 btn.disabled = false; btn.textContent = _I18N.save;
@@ -1118,7 +1119,7 @@
             document.getElementById('info-tab-history').innerHTML = '';
             openModal('modal-info-indexer');
 
-            fetch('/prowlarr/indexer/' + id)
+            fetch(BASE + '/prowlarr/indexer/' + id)
                 .then(function(r) { return r.json(); })
                 .then(function(raw) {
                     infoRaw = raw;
@@ -1133,7 +1134,7 @@
                         if (histLoaded) return;
                         histLoaded = true;
                         document.getElementById('info-tab-history').innerHTML = '<div class="text-center py-3"><div class="spinner-border spinner-border-sm text-secondary"></div></div>';
-                        fetch('/prowlarr/indexer/' + idxId + '/history')
+                        fetch(BASE + '/prowlarr/indexer/' + idxId + '/history')
                             .then(function(r) { return r.json(); })
                             .then(function(records) { renderInfoHistory(records); });
                     });
@@ -1154,7 +1155,7 @@
 
         var torznabUrl = '';
         if (raw.indexerUrls && raw.indexerUrls.length) {
-            torznabUrl = window.location.origin + '/prowlarr/indexer/' + raw.id;
+            torznabUrl = window.location.origin + BASE + '/prowlarr/indexer/' + raw.id;
         }
 
         var h = '<h6 class="mb-3" style="color:#E88D1A;">' + esc(_I18N.infoDetailsHeading) + '</h6>';
@@ -1254,7 +1255,7 @@
     document.getElementById('info-idx-delete').addEventListener('click', function() {
         if (!infoRaw) return;
         if (!confirm(_I18N.confirmDeleteIndexerTpl.replace('__NAME__', infoRaw.name || ''))) return;
-        fetch('/prowlarr/indexer/' + infoRaw.id + '/delete', { method: 'POST' })
+        fetch(BASE + '/prowlarr/indexer/' + infoRaw.id + '/delete', { method: 'POST' })
             .then(function(r) { return r.json(); })
             .then(function(d) { if (d.ok) { closeModal('modal-info-indexer'); window.location.reload(); } });
     });

--- a/symfony/templates/prowlarr/index.html.twig
+++ b/symfony/templates/prowlarr/index.html.twig
@@ -408,6 +408,7 @@
 {% block javascripts %}
 <script>
 (function () {
+    var BASE = window.BASE_PATH;
     var _I18N = {
         name: {{ 'prowlarr.common.name'|trans|json_encode|raw }},
         appProfile: {{ 'prowlarr.index.field_app_profile'|trans|json_encode|raw }},
@@ -540,7 +541,7 @@
             h += '</div>';
             // Charger app profiles
             if (!appProfilesCache) {
-                fetch('/prowlarr/app-profiles').then(function(r){return r.json();}).then(function(profiles) {
+                fetch(BASE + '/prowlarr/app-profiles').then(function(r){return r.json();}).then(function(profiles) {
                     appProfilesCache = profiles;
                     fillAppProfileSelect(topLevel.appProfileId);
                 });
@@ -599,7 +600,7 @@
     function loadAndRenderTags(currentTags) {
         selectedTags = currentTags || [];
         if (!tagsCache) {
-            fetch('/prowlarr/tags').then(function(r) { return r.json(); }).then(function(tags) {
+            fetch(BASE + '/prowlarr/tags').then(function(r) { return r.json(); }).then(function(tags) {
                 tagsCache = tags;
                 renderTagsUI();
             });
@@ -653,7 +654,7 @@
         var label = (input.value || '').trim();
         if (!label) return;
         input.disabled = true;
-        fetch('/prowlarr/tag/create', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ label: label }) })
+        fetch(BASE + '/prowlarr/tag/create', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ label: label }) })
             .then(function(r) { return r.json(); })
             .then(function(d) {
                 input.disabled = false;
@@ -706,7 +707,7 @@
     document.querySelectorAll('[data-toggle-id]').forEach(function (btn) {
         btn.addEventListener('click', function () {
             btn.disabled = true; btn.textContent = '…';
-            fetch('/prowlarr/indexer/' + btn.dataset.toggleId + '/toggle', { method: 'POST' })
+            fetch(BASE + '/prowlarr/indexer/' + btn.dataset.toggleId + '/toggle', { method: 'POST' })
                 .then(function (r) { return r.json(); })
                 .then(function (d) { btn.disabled = false; if (d.ok) { btn.classList.toggle('is-on', d.enabled); btn.classList.toggle('is-off', !d.enabled); btn.textContent = d.enabled ? 'ON' : 'OFF'; } });
         });
@@ -716,7 +717,7 @@
     document.querySelectorAll('[data-delete-id]').forEach(function (btn) {
         btn.addEventListener('click', function () {
             if (!confirm(_I18N.confirmDeleteIndexerTpl.replace('__NAME__', btn.dataset.deleteName))) return;
-            fetch('/prowlarr/indexer/' + btn.dataset.deleteId + '/delete', { method: 'POST' })
+            fetch(BASE + '/prowlarr/indexer/' + btn.dataset.deleteId + '/delete', { method: 'POST' })
                 .then(function (r) { return r.json(); })
                 .then(function (d) { if (d.ok) { var row = btn.closest('tr'); if (row) row.remove(); } });
         });
@@ -729,10 +730,10 @@
             var orig = btn.innerHTML;
             btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:.7rem;height:.7rem;"></span>';
             btn.disabled = true;
-            fetch('/prowlarr/indexer/' + id, { method: 'GET' })
+            fetch(BASE + '/prowlarr/indexer/' + id, { method: 'GET' })
                 .then(function (r) { return r.json(); })
                 .then(function (raw) {
-                    return fetch('/prowlarr/indexer/test', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(cleanPayload(raw)) });
+                    return fetch(BASE + '/prowlarr/indexer/test', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(cleanPayload(raw)) });
                 })
                 .then(function (r) { return r.json(); })
                 .then(function (d) {
@@ -749,7 +750,7 @@
         var btn = this;
         btn.disabled = true;
         btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:.7rem;height:.7rem;"></span> ' + _I18N.testAllInProgress;
-        fetch('/prowlarr/indexer/testall', { method: 'POST' })
+        fetch(BASE + '/prowlarr/indexer/testall', { method: 'POST' })
             .then(function (r) { return r.json(); })
             .then(function (d) {
                 btn.disabled = false;
@@ -782,7 +783,7 @@
     document.getElementById('btn-sync-indexers').addEventListener('click', function () {
         var btn = this; btn.disabled = true;
         btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:.7rem;height:.7rem;"></span> ' + _I18N.syncInProgress;
-        fetch('/prowlarr/command', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: 'ApplicationIndexerSync' }) })
+        fetch(BASE + '/prowlarr/command', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: 'ApplicationIndexerSync' }) })
             .then(function (r) { return r.json(); })
             .then(function (d) {
                 if (!d.ok) { btn.disabled = false; btn.innerHTML = syncOrigHtml; return; }
@@ -790,7 +791,7 @@
                 if (!cmdId) { btn.disabled = false; btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2" class="me-1"><path d="M5 12l5 5l10-10"/></svg> ' + _I18N.syncDone; setTimeout(function(){btn.innerHTML=syncOrigHtml;},2000); return; }
                 // Poll command status
                 var poll = setInterval(function () {
-                    fetch('/prowlarr/command/' + cmdId)
+                    fetch(BASE + '/prowlarr/command/' + cmdId)
                         .then(function(r){return r.json();})
                         .then(function(s) {
                             if (!s || s.status === 'completed') {
@@ -821,7 +822,7 @@
         var q = searchInput.value.trim();
         if (q.length < 2) return;
         searchLoading.style.display = ''; searchResults.innerHTML = ''; searchBtn.disabled = true;
-        fetch('/prowlarr/search?q=' + encodeURIComponent(q))
+        fetch(BASE + '/prowlarr/search?q=' + encodeURIComponent(q))
             .then(function (r) { return r.json(); })
             .then(function (items) {
                 searchLoading.style.display = 'none'; searchBtn.disabled = false;
@@ -863,7 +864,7 @@
         openModal('modal-add-indexer');
         if (!schemaCache) {
             document.getElementById('add-idx-list').innerHTML = '<div class="col-12 text-center py-3"><div class="spinner-border spinner-border-sm text-secondary"></div></div>';
-            fetch('/prowlarr/indexer/schema').then(function (r) { return r.json(); }).then(function (data) { schemaCache = data; populateFilterDropdowns(); renderSchemaList(getAddFilters()); });
+            fetch(BASE + '/prowlarr/indexer/schema').then(function (r) { return r.json(); }).then(function (data) { schemaCache = data; populateFilterDropdowns(); renderSchemaList(getAddFilters()); });
         } else { renderSchemaList(getAddFilters()); }
     });
 
@@ -987,7 +988,7 @@
         var payload = collectTopLevel(document.getElementById('add-idx-fields'), selectedSchema);
         payload.fields = collectFields(document.getElementById('add-idx-fields'), selectedSchema.fields || []);
         btn.disabled = true; btn.textContent = _I18N.testing;
-        fetch('/prowlarr/indexer/test', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(cleanPayload(payload)) })
+        fetch(BASE + '/prowlarr/indexer/test', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(cleanPayload(payload)) })
             .then(function (r) { return r.json(); })
             .then(function (d) {
                 btn.disabled = false; btn.textContent = _I18N.test;
@@ -1001,7 +1002,7 @@
         var payload = collectTopLevel(document.getElementById('add-idx-fields'), selectedSchema);
         payload.fields = collectFields(document.getElementById('add-idx-fields'), selectedSchema.fields || []);
         btn.disabled = true; btn.textContent = _I18N.adding;
-        fetch('/prowlarr/indexer/add', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(cleanPayload(payload)) })
+        fetch(BASE + '/prowlarr/indexer/add', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(cleanPayload(payload)) })
             .then(function (r) { return r.json(); })
             .then(function (d) {
                 btn.disabled = false; btn.textContent = _I18N.add;
@@ -1043,7 +1044,7 @@
             document.getElementById('edit-idx-fields').innerHTML = '<div class="text-center py-3"><div class="spinner-border spinner-border-sm text-secondary"></div></div>';
             document.getElementById('edit-idx-result').className = 'mt-2 alert d-none';
             openModal('modal-edit-indexer');
-            fetch('/prowlarr/indexer/' + id)
+            fetch(BASE + '/prowlarr/indexer/' + id)
                 .then(function (r) { return r.json(); })
                 .then(function (raw) {
                     editRaw = raw;
@@ -1065,7 +1066,7 @@
         var payload = collectTopLevel(document.getElementById('edit-idx-fields'), editRaw);
         payload.fields = collectFields(document.getElementById('edit-idx-fields'), editRaw.fields || []);
         btn.disabled = true; btn.textContent = _I18N.testing;
-        fetch('/prowlarr/indexer/test', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(cleanPayload(payload)) })
+        fetch(BASE + '/prowlarr/indexer/test', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(cleanPayload(payload)) })
             .then(function (r) { return r.json(); })
             .then(function (d) {
                 btn.disabled = false; btn.textContent = _I18N.test;
@@ -1079,7 +1080,7 @@
         var payload = collectTopLevel(document.getElementById('edit-idx-fields'), editRaw);
         payload.fields = collectFields(document.getElementById('edit-idx-fields'), editRaw.fields || []);
         btn.disabled = true; btn.textContent = _I18N.saving;
-        fetch('/prowlarr/indexer/' + editRaw.id + '/update', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(cleanPayload(payload)) })
+        fetch(BASE + '/prowlarr/indexer/' + editRaw.id + '/update', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(cleanPayload(payload)) })
             .then(function (r) { return r.json(); })
             .then(function (d) {
                 btn.disabled = false; btn.textContent = _I18N.save;
@@ -1118,7 +1119,7 @@
             document.getElementById('info-tab-history').innerHTML = '';
             openModal('modal-info-indexer');
 
-            fetch('/prowlarr/indexer/' + id)
+            fetch(BASE + '/prowlarr/indexer/' + id)
                 .then(function(r) { return r.json(); })
                 .then(function(raw) {
                     infoRaw = raw;
@@ -1133,7 +1134,7 @@
                         if (histLoaded) return;
                         histLoaded = true;
                         document.getElementById('info-tab-history').innerHTML = '<div class="text-center py-3"><div class="spinner-border spinner-border-sm text-secondary"></div></div>';
-                        fetch('/prowlarr/indexer/' + idxId + '/history')
+                        fetch(BASE + '/prowlarr/indexer/' + idxId + '/history')
                             .then(function(r) { return r.json(); })
                             .then(function(records) { renderInfoHistory(records); });
                     });
@@ -1154,7 +1155,7 @@
 
         var torznabUrl = '';
         if (raw.indexerUrls && raw.indexerUrls.length) {
-            torznabUrl = window.location.origin + '/prowlarr/indexer/' + raw.id;
+            torznabUrl = window.location.origin + BASE + '/prowlarr/indexer/' + raw.id;
         }
 
         var h = '<h6 class="mb-3" style="color:#E88D1A;">' + esc(_I18N.infoDetailsHeading) + '</h6>';
@@ -1254,7 +1255,7 @@
     document.getElementById('info-idx-delete').addEventListener('click', function() {
         if (!infoRaw) return;
         if (!confirm(_I18N.confirmDeleteIndexerTpl.replace('__NAME__', infoRaw.name || ''))) return;
-        fetch('/prowlarr/indexer/' + infoRaw.id + '/delete', { method: 'POST' })
+        fetch(BASE + '/prowlarr/indexer/' + infoRaw.id + '/delete', { method: 'POST' })
             .then(function(r) { return r.json(); })
             .then(function(d) { if (d.ok) { closeModal('modal-info-indexer'); window.location.reload(); } });
     });

--- a/symfony/templates/prowlarr/notifications.html.twig
+++ b/symfony/templates/prowlarr/notifications.html.twig
@@ -116,12 +116,13 @@
 {% block javascripts %}
 <script>
 (function () {
-    var SCHEMA_URL = '/prowlarr/notification/schema';
-    var GET_URL = '/prowlarr/notification/{id}';
-    var ADD_URL = '/prowlarr/notification/add';
-    var UPDATE_URL = '/prowlarr/notification/{id}/update';
-    var DELETE_URL = '/prowlarr/notification/{id}/delete';
-    var TEST_URL = '/prowlarr/notification/test';
+    var BASE = '{{ app.request.getBasePath() }}';
+    var SCHEMA_URL = BASE + '/prowlarr/notification/schema';
+    var GET_URL = BASE + '/prowlarr/notification/{id}';
+    var ADD_URL = BASE + '/prowlarr/notification/add';
+    var UPDATE_URL = BASE + '/prowlarr/notification/{id}/update';
+    var DELETE_URL = BASE + '/prowlarr/notification/{id}/delete';
+    var TEST_URL = BASE + '/prowlarr/notification/test';
 
     var _I18N = {
         name: {{ 'prowlarr.common.name'|trans|json_encode|raw }},

--- a/symfony/templates/prowlarr/notifications.html.twig
+++ b/symfony/templates/prowlarr/notifications.html.twig
@@ -116,12 +116,13 @@
 {% block javascripts %}
 <script>
 (function () {
-    var SCHEMA_URL = '/prowlarr/notification/schema';
-    var GET_URL = '/prowlarr/notification/{id}';
-    var ADD_URL = '/prowlarr/notification/add';
-    var UPDATE_URL = '/prowlarr/notification/{id}/update';
-    var DELETE_URL = '/prowlarr/notification/{id}/delete';
-    var TEST_URL = '/prowlarr/notification/test';
+    var BASE = window.BASE_PATH;
+    var SCHEMA_URL = BASE + '/prowlarr/notification/schema';
+    var GET_URL = BASE + '/prowlarr/notification/{id}';
+    var ADD_URL = BASE + '/prowlarr/notification/add';
+    var UPDATE_URL = BASE + '/prowlarr/notification/{id}/update';
+    var DELETE_URL = BASE + '/prowlarr/notification/{id}/delete';
+    var TEST_URL = BASE + '/prowlarr/notification/test';
 
     var _I18N = {
         name: {{ 'prowlarr.common.name'|trans|json_encode|raw }},

--- a/symfony/templates/prowlarr/tags.html.twig
+++ b/symfony/templates/prowlarr/tags.html.twig
@@ -98,6 +98,7 @@
 {% block javascripts %}
 <script>
 (function () {
+    var BASE = '{{ app.request.getBasePath() }}';
     var _I18N = {
         created: {{ 'prowlarr.tags.feedback_created'|trans|json_encode|raw }},
         error: {{ 'prowlarr.tags.feedback_error'|trans|json_encode|raw }},
@@ -141,7 +142,7 @@
     document.querySelectorAll('.btn-tag-delete').forEach(function (btn) {
         btn.addEventListener('click', function () {
             if (!confirm(_I18N.confirmDeleteTpl.replace('__LABEL__', btn.dataset.label))) return;
-            fetch('/prowlarr/tags/' + btn.dataset.id + '/supprimer', { method: 'POST', credentials: 'same-origin' })
+            fetch(BASE + '/prowlarr/tags/' + btn.dataset.id + '/supprimer', { method: 'POST', credentials: 'same-origin' })
                 .then(function (r) { return r.json(); })
                 .then(function (d) {
                     if (d.ok) {

--- a/symfony/templates/prowlarr/tags.html.twig
+++ b/symfony/templates/prowlarr/tags.html.twig
@@ -98,6 +98,7 @@
 {% block javascripts %}
 <script>
 (function () {
+    var BASE = window.BASE_PATH;
     var _I18N = {
         created: {{ 'prowlarr.tags.feedback_created'|trans|json_encode|raw }},
         error: {{ 'prowlarr.tags.feedback_error'|trans|json_encode|raw }},
@@ -141,7 +142,7 @@
     document.querySelectorAll('.btn-tag-delete').forEach(function (btn) {
         btn.addEventListener('click', function () {
             if (!confirm(_I18N.confirmDeleteTpl.replace('__LABEL__', btn.dataset.label))) return;
-            fetch('/prowlarr/tags/' + btn.dataset.id + '/supprimer', { method: 'POST', credentials: 'same-origin' })
+            fetch(BASE + '/prowlarr/tags/' + btn.dataset.id + '/supprimer', { method: 'POST', credentials: 'same-origin' })
                 .then(function (r) { return r.json(); })
                 .then(function (d) {
                     if (d.ok) {

--- a/symfony/templates/prowlarr/ui.html.twig
+++ b/symfony/templates/prowlarr/ui.html.twig
@@ -134,6 +134,7 @@
 {% block javascripts %}
 <script>
 (function () {
+    var BASE = '{{ app.request.getBasePath() }}';
     var _I18N = {
         saveBtn: {{ 'prowlarr.ui.save_btn'|trans|json_encode|raw }},
         saving: {{ 'prowlarr.common.saving'|trans|json_encode|raw }},
@@ -156,7 +157,7 @@
         btn.disabled = true;
         btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + _I18N.saving;
 
-        fetch('/prowlarr/ui/save', {
+        fetch(BASE + '/prowlarr/ui/save', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload)

--- a/symfony/templates/prowlarr/ui.html.twig
+++ b/symfony/templates/prowlarr/ui.html.twig
@@ -134,6 +134,7 @@
 {% block javascripts %}
 <script>
 (function () {
+    var BASE = window.BASE_PATH;
     var _I18N = {
         saveBtn: {{ 'prowlarr.ui.save_btn'|trans|json_encode|raw }},
         saving: {{ 'prowlarr.common.saving'|trans|json_encode|raw }},
@@ -156,7 +157,7 @@
         btn.disabled = true;
         btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span> ' + _I18N.saving;
 
-        fetch('/prowlarr/ui/save', {
+        fetch(BASE + '/prowlarr/ui/save', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload)

--- a/symfony/templates/prowlarr/updates.html.twig
+++ b/symfony/templates/prowlarr/updates.html.twig
@@ -177,6 +177,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = '{{ app.request.getBasePath() }}';
 var _I18N = {
     starting: {{ 'prowlarr.updates.install_starting'|trans|json_encode|raw }},
     launched: {{ 'prowlarr.updates.install_launched'|trans|json_encode|raw }},
@@ -193,7 +194,7 @@ document.querySelectorAll('.btn-install').forEach(function(btn) {
         progress.classList.remove('d-none');
         msg.textContent = _I18N.starting;
 
-        fetch('/prowlarr/command', {
+        fetch(BASE + '/prowlarr/command', {
             method: 'POST',
             headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
             body: JSON.stringify({name: 'ApplicationUpdateCheck'}),

--- a/symfony/templates/prowlarr/updates.html.twig
+++ b/symfony/templates/prowlarr/updates.html.twig
@@ -177,6 +177,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = window.BASE_PATH;
 var _I18N = {
     starting: {{ 'prowlarr.updates.install_starting'|trans|json_encode|raw }},
     launched: {{ 'prowlarr.updates.install_launched'|trans|json_encode|raw }},
@@ -193,7 +194,7 @@ document.querySelectorAll('.btn-install').forEach(function(btn) {
         progress.classList.remove('d-none');
         msg.textContent = _I18N.starting;
 
-        fetch('/prowlarr/command', {
+        fetch(BASE + '/prowlarr/command', {
             method: 'POST',
             headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
             body: JSON.stringify({name: 'ApplicationUpdateCheck'}),

--- a/symfony/templates/radarr/_schema_modal.html.twig
+++ b/symfony/templates/radarr/_schema_modal.html.twig
@@ -6,8 +6,8 @@
     modal_title_edit: edit title (ex: 'Edit the indexer')
     schema_url     : URL of the GET schema endpoint (ex: instance_path('radarr_indexers_schema'))
     save_url_add   : POST URL to create (ex: instance_path('radarr_indexer_add'))
-    save_url_edit  : POST URL to edit — __ID__ is replaced by the id (ex: '/medias/' + INSTANCE_SLUG + '/radarr/indexeurs/__ID__/modifier')
-    test_url       : (optional) POST URL to test (ex: '/medias/' + INSTANCE_SLUG + '/radarr/indexeurs/__ID__/tester')
+    save_url_edit  : POST URL to edit — __ID__ is replaced by the id (ex: BASE + '/medias/' + INSTANCE_SLUG + '/radarr/indexeurs/__ID__/modifier')
+    test_url       : (optional) POST URL to test (ex: BASE + '/medias/' + INSTANCE_SLUG + '/radarr/indexeurs/__ID__/tester')
     mode           : 'default' | 'notification' — notifications show triggers instead of RSS/search options
 #}
 <div class="modal modal-blur fade" id="{{ modal_id }}" tabindex="-1">
@@ -88,6 +88,7 @@
 
 <script>
 (function () {
+  var BASE = '{{ app.request.getBasePath() }}';
   var MID        = {{ modal_id|json_encode|raw }};
   var SCHEMA_URL = {{ schema_url|json_encode|raw }};
   var SAVE_ADD   = {{ save_url_add|json_encode|raw }};
@@ -330,7 +331,7 @@
         schemaCache = Array.isArray(data) ? data : [];
         // Auto-detect Radarr vs Sonarr from the schema URL to show the right message
         if (!schemaCache.length) {
-          var isSonarr = SCHEMA_URL.indexOf('/medias/' + INSTANCE_SLUG + '/sonarr/') !== -1;
+          var isSonarr = SCHEMA_URL.indexOf(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/') !== -1;
           showFeedback(isSonarr ? I18N.error_schema_none_sonarr : I18N.error_schema_none_radarr, 'warning');
         }
         return schemaCache;

--- a/symfony/templates/radarr/_schema_modal.html.twig
+++ b/symfony/templates/radarr/_schema_modal.html.twig
@@ -6,8 +6,8 @@
     modal_title_edit: edit title (ex: 'Edit the indexer')
     schema_url     : URL of the GET schema endpoint (ex: instance_path('radarr_indexers_schema'))
     save_url_add   : POST URL to create (ex: instance_path('radarr_indexer_add'))
-    save_url_edit  : POST URL to edit — __ID__ is replaced by the id (ex: '/medias/' + INSTANCE_SLUG + '/radarr/indexeurs/__ID__/modifier')
-    test_url       : (optional) POST URL to test (ex: '/medias/' + INSTANCE_SLUG + '/radarr/indexeurs/__ID__/tester')
+    save_url_edit  : POST URL to edit — __ID__ is replaced by the id (ex: BASE + '/medias/' + INSTANCE_SLUG + '/radarr/indexeurs/__ID__/modifier')
+    test_url       : (optional) POST URL to test (ex: BASE + '/medias/' + INSTANCE_SLUG + '/radarr/indexeurs/__ID__/tester')
     mode           : 'default' | 'notification' — notifications show triggers instead of RSS/search options
 #}
 <div class="modal modal-blur fade" id="{{ modal_id }}" tabindex="-1">
@@ -88,6 +88,7 @@
 
 <script>
 (function () {
+  var BASE = window.BASE_PATH;
   var MID        = {{ modal_id|json_encode|raw }};
   var SCHEMA_URL = {{ schema_url|json_encode|raw }};
   var SAVE_ADD   = {{ save_url_add|json_encode|raw }};
@@ -330,7 +331,7 @@
         schemaCache = Array.isArray(data) ? data : [];
         // Auto-detect Radarr vs Sonarr from the schema URL to show the right message
         if (!schemaCache.length) {
-          var isSonarr = SCHEMA_URL.indexOf('/medias/' + INSTANCE_SLUG + '/sonarr/') !== -1;
+          var isSonarr = SCHEMA_URL.indexOf(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/') !== -1;
           showFeedback(isSonarr ? I18N.error_schema_none_sonarr : I18N.error_schema_none_radarr, 'warning');
         }
         return schemaCache;

--- a/symfony/templates/radarr/auto_tags.html.twig
+++ b/symfony/templates/radarr/auto_tags.html.twig
@@ -171,6 +171,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = '{{ app.request.getBasePath() }}';
   var _I18N = {
     modal_title_new: {{ 'media.arr_admin.auto_tags.modal_title_new'|trans|json_encode|raw }},
     modal_title_edit: {{ 'media.arr_admin.auto_tags.modal_title_edit_tpl'|trans({name: '__NAME__'})|json_encode|raw }},
@@ -395,7 +396,7 @@
     var url;
     if (editingItem) {
       payload.id = editingItem.id;
-      url = '/medias/' + INSTANCE_SLUG + '/radarr/auto-tags/' + editingItem.id + '/modifier';
+      url = BASE + '/medias/' + INSTANCE_SLUG + '/radarr/auto-tags/' + editingItem.id + '/modifier';
     } else {
       url = {{ instance_path('radarr_auto_tag_add')|json_encode|raw }};
     }
@@ -422,7 +423,7 @@
   document.querySelectorAll('.btn-at-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(_I18N.delete_confirm_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/auto-tags/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/auto-tags/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}'

--- a/symfony/templates/radarr/auto_tags.html.twig
+++ b/symfony/templates/radarr/auto_tags.html.twig
@@ -171,6 +171,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = window.BASE_PATH;
   var _I18N = {
     modal_title_new: {{ 'media.arr_admin.auto_tags.modal_title_new'|trans|json_encode|raw }},
     modal_title_edit: {{ 'media.arr_admin.auto_tags.modal_title_edit_tpl'|trans({name: '__NAME__'})|json_encode|raw }},
@@ -395,7 +396,7 @@
     var url;
     if (editingItem) {
       payload.id = editingItem.id;
-      url = '/medias/' + INSTANCE_SLUG + '/radarr/auto-tags/' + editingItem.id + '/modifier';
+      url = BASE + '/medias/' + INSTANCE_SLUG + '/radarr/auto-tags/' + editingItem.id + '/modifier';
     } else {
       url = {{ instance_path('radarr_auto_tag_add')|json_encode|raw }};
     }
@@ -422,7 +423,7 @@
   document.querySelectorAll('.btn-at-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(_I18N.delete_confirm_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/auto-tags/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/auto-tags/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}'

--- a/symfony/templates/radarr/backups.html.twig
+++ b/symfony/templates/radarr/backups.html.twig
@@ -125,6 +125,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = '{{ app.request.getBasePath() }}';
 var I18N = {
   starting: {{ 'media.arr_admin.backups.backup_starting'|trans|json_encode|raw }},
   statusTpl: {{ 'media.arr_admin.backups.backup_status_tpl'|trans({status: '__STATUS__'})|json_encode|raw }},
@@ -185,7 +186,7 @@ document.querySelectorAll('.btn-backup-delete').forEach(function(btn) {
   btn.onclick = function() {
     if (!confirm(I18N.confirmDelete)) return;
     var id = btn.dataset.id;
-    fetch('/medias/' + INSTANCE_SLUG + '/radarr/sauvegardes/' + id + '/supprimer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/sauvegardes/' + id + '/supprimer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}'
@@ -219,7 +220,7 @@ if (btnConfirmRestore) {
     alertEl.classList.remove('d-none');
     msg.textContent = I18N.restoreInProgress;
 
-    fetch('/medias/' + INSTANCE_SLUG + '/radarr/sauvegardes/' + pendingRestoreId + '/restaurer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/sauvegardes/' + pendingRestoreId + '/restaurer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}'

--- a/symfony/templates/radarr/backups.html.twig
+++ b/symfony/templates/radarr/backups.html.twig
@@ -125,6 +125,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = window.BASE_PATH;
 var I18N = {
   starting: {{ 'media.arr_admin.backups.backup_starting'|trans|json_encode|raw }},
   statusTpl: {{ 'media.arr_admin.backups.backup_status_tpl'|trans({status: '__STATUS__'})|json_encode|raw }},
@@ -185,7 +186,7 @@ document.querySelectorAll('.btn-backup-delete').forEach(function(btn) {
   btn.onclick = function() {
     if (!confirm(I18N.confirmDelete)) return;
     var id = btn.dataset.id;
-    fetch('/medias/' + INSTANCE_SLUG + '/radarr/sauvegardes/' + id + '/supprimer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/sauvegardes/' + id + '/supprimer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}'
@@ -219,7 +220,7 @@ if (btnConfirmRestore) {
     alertEl.classList.remove('d-none');
     msg.textContent = I18N.restoreInProgress;
 
-    fetch('/medias/' + INSTANCE_SLUG + '/radarr/sauvegardes/' + pendingRestoreId + '/restaurer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/sauvegardes/' + pendingRestoreId + '/restaurer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}'

--- a/symfony/templates/radarr/commands.html.twig
+++ b/symfony/templates/radarr/commands.html.twig
@@ -112,6 +112,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = '{{ app.request.getBasePath() }}';
 var I18N = {
   confirmCancelTpl: {{ 'media.arr_admin.commands.confirm_cancel_tpl'|trans({id: '__ID__'})|json_encode|raw }},
   cancelledTpl: {{ 'media.arr_admin.commands.cancelled_tpl'|trans({id: '__ID__'})|json_encode|raw }},
@@ -132,7 +133,7 @@ function bindCancelButtons() {
       var cmdId = btn.dataset.id;
       if (!confirm(I18N.confirmCancelTpl.replace('__ID__', cmdId))) return;
       btn.disabled = true;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/command/' + cmdId + '/annuler', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/command/' + cmdId + '/annuler', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}'

--- a/symfony/templates/radarr/commands.html.twig
+++ b/symfony/templates/radarr/commands.html.twig
@@ -112,6 +112,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = window.BASE_PATH;
 var I18N = {
   confirmCancelTpl: {{ 'media.arr_admin.commands.confirm_cancel_tpl'|trans({id: '__ID__'})|json_encode|raw }},
   cancelledTpl: {{ 'media.arr_admin.commands.cancelled_tpl'|trans({id: '__ID__'})|json_encode|raw }},
@@ -132,7 +133,7 @@ function bindCancelButtons() {
       var cmdId = btn.dataset.id;
       if (!confirm(I18N.confirmCancelTpl.replace('__ID__', cmdId))) return;
       btn.disabled = true;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/command/' + cmdId + '/annuler', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/command/' + cmdId + '/annuler', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}'

--- a/symfony/templates/radarr/custom_filters.html.twig
+++ b/symfony/templates/radarr/custom_filters.html.twig
@@ -109,6 +109,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = '{{ app.request.getBasePath() }}';
   var CF_I18N = {
     title_add: {{ 'media.arr_admin.custom_filters.modal_title_add'|trans|json_encode|raw }},
     title_edit: {{ 'media.arr_admin.custom_filters.modal_title_edit'|trans|json_encode|raw }},
@@ -165,7 +166,7 @@
     var filters;
     try { filters = JSON.parse(filtersRaw || '[]'); } catch(e) { showModalFeedback(CF_I18N.err_invalid_json, 'danger'); return; }
     var payload = {label: label, type: type, filters: filters};
-    var url = id ? '/medias/' + INSTANCE_SLUG + '/radarr/filtres-personnalises/' + id + '/modifier' : '{{ instance_path("radarr_custom_filter_add") }}';
+    var url = id ? BASE + '/medias/' + INSTANCE_SLUG + '/radarr/filtres-personnalises/' + id + '/modifier' : '{{ instance_path("radarr_custom_filter_add") }}';
     if (id) payload.id = parseInt(id, 10);
     fetch(url, {
       method: 'POST',
@@ -180,7 +181,7 @@
   document.querySelectorAll('.btn-cf-delete').forEach(function(btn) {
     btn.onclick = function() {
       if (!confirm(CF_I18N.delete_confirm_tpl.replace('__LABEL__', btn.dataset.label))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/filtres-personnalises/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/filtres-personnalises/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}',

--- a/symfony/templates/radarr/custom_filters.html.twig
+++ b/symfony/templates/radarr/custom_filters.html.twig
@@ -109,6 +109,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = window.BASE_PATH;
   var CF_I18N = {
     title_add: {{ 'media.arr_admin.custom_filters.modal_title_add'|trans|json_encode|raw }},
     title_edit: {{ 'media.arr_admin.custom_filters.modal_title_edit'|trans|json_encode|raw }},
@@ -165,7 +166,7 @@
     var filters;
     try { filters = JSON.parse(filtersRaw || '[]'); } catch(e) { showModalFeedback(CF_I18N.err_invalid_json, 'danger'); return; }
     var payload = {label: label, type: type, filters: filters};
-    var url = id ? '/medias/' + INSTANCE_SLUG + '/radarr/filtres-personnalises/' + id + '/modifier' : '{{ instance_path("radarr_custom_filter_add") }}';
+    var url = id ? BASE + '/medias/' + INSTANCE_SLUG + '/radarr/filtres-personnalises/' + id + '/modifier' : '{{ instance_path("radarr_custom_filter_add") }}';
     if (id) payload.id = parseInt(id, 10);
     fetch(url, {
       method: 'POST',
@@ -180,7 +181,7 @@
   document.querySelectorAll('.btn-cf-delete').forEach(function(btn) {
     btn.onclick = function() {
       if (!confirm(CF_I18N.delete_confirm_tpl.replace('__LABEL__', btn.dataset.label))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/filtres-personnalises/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/filtres-personnalises/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}',

--- a/symfony/templates/radarr/custom_formats.html.twig
+++ b/symfony/templates/radarr/custom_formats.html.twig
@@ -166,6 +166,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = '{{ app.request.getBasePath() }}';
   var I18N = {
     modal_new: {{ 'media.arr_admin.custom_formats.modal_new'|trans|json_encode|raw }},
     modal_edit_tpl: {{ 'media.arr_admin.custom_formats.modal_edit_tpl'|trans({name: '__NAME__'})|json_encode|raw }},
@@ -476,7 +477,7 @@
     try {
       var url = SAVE_URL;
       if (editingItem) {
-        url = '/medias/' + INSTANCE_SLUG + '/radarr/formats/' + editingItem.id + '/modifier';
+        url = BASE + '/medias/' + INSTANCE_SLUG + '/radarr/formats/' + editingItem.id + '/modifier';
       }
       var r = await fetch(url, {
         method: 'POST',
@@ -504,7 +505,7 @@
     var btn = e.target.closest('.btn-cf-delete');
     if (!btn) return;
     if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-    fetch('/medias/' + INSTANCE_SLUG + '/radarr/formats/' + btn.dataset.id + '/supprimer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/formats/' + btn.dataset.id + '/supprimer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}',

--- a/symfony/templates/radarr/custom_formats.html.twig
+++ b/symfony/templates/radarr/custom_formats.html.twig
@@ -166,6 +166,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = window.BASE_PATH;
   var I18N = {
     modal_new: {{ 'media.arr_admin.custom_formats.modal_new'|trans|json_encode|raw }},
     modal_edit_tpl: {{ 'media.arr_admin.custom_formats.modal_edit_tpl'|trans({name: '__NAME__'})|json_encode|raw }},
@@ -476,7 +477,7 @@
     try {
       var url = SAVE_URL;
       if (editingItem) {
-        url = '/medias/' + INSTANCE_SLUG + '/radarr/formats/' + editingItem.id + '/modifier';
+        url = BASE + '/medias/' + INSTANCE_SLUG + '/radarr/formats/' + editingItem.id + '/modifier';
       }
       var r = await fetch(url, {
         method: 'POST',
@@ -504,7 +505,7 @@
     var btn = e.target.closest('.btn-cf-delete');
     if (!btn) return;
     if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-    fetch('/medias/' + INSTANCE_SLUG + '/radarr/formats/' + btn.dataset.id + '/supprimer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/formats/' + btn.dataset.id + '/supprimer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}',

--- a/symfony/templates/radarr/delay_profiles.html.twig
+++ b/symfony/templates/radarr/delay_profiles.html.twig
@@ -192,6 +192,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = '{{ app.request.getBasePath() }}';
   var I18N = {
     modal_new: {{ 'media.arr_admin.delay_profiles.modal_new'|trans|json_encode|raw }},
     modal_edit_tpl: {{ 'media.arr_admin.delay_profiles.modal_edit_tpl'|trans({id: '__ID__'})|json_encode|raw }},
@@ -282,7 +283,7 @@
     if (editingItem) {
       payload.id = editingItem.id;
       payload.order = editingItem.order;
-      url = '/medias/' + INSTANCE_SLUG + '/radarr/profils-delai/' + editingItem.id + '/modifier';
+      url = BASE + '/medias/' + INSTANCE_SLUG + '/radarr/profils-delai/' + editingItem.id + '/modifier';
     } else {
       url = {{ instance_path('radarr_delay_profile_add')|json_encode|raw }};
     }
@@ -309,7 +310,7 @@
   document.querySelectorAll('.btn-delay-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(I18N.confirm_delete)) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/profils-delai/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/profils-delai/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}'

--- a/symfony/templates/radarr/delay_profiles.html.twig
+++ b/symfony/templates/radarr/delay_profiles.html.twig
@@ -192,6 +192,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = window.BASE_PATH;
   var I18N = {
     modal_new: {{ 'media.arr_admin.delay_profiles.modal_new'|trans|json_encode|raw }},
     modal_edit_tpl: {{ 'media.arr_admin.delay_profiles.modal_edit_tpl'|trans({id: '__ID__'})|json_encode|raw }},
@@ -282,7 +283,7 @@
     if (editingItem) {
       payload.id = editingItem.id;
       payload.order = editingItem.order;
-      url = '/medias/' + INSTANCE_SLUG + '/radarr/profils-delai/' + editingItem.id + '/modifier';
+      url = BASE + '/medias/' + INSTANCE_SLUG + '/radarr/profils-delai/' + editingItem.id + '/modifier';
     } else {
       url = {{ instance_path('radarr_delay_profile_add')|json_encode|raw }};
     }
@@ -309,7 +310,7 @@
   document.querySelectorAll('.btn-delay-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(I18N.confirm_delete)) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/profils-delai/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/profils-delai/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}'

--- a/symfony/templates/radarr/download_clients.html.twig
+++ b/symfony/templates/radarr/download_clients.html.twig
@@ -109,7 +109,7 @@
   modal_title_edit: 'media.arr_admin.download_clients.modal_title_edit'|trans,
   schema_url: instance_path('radarr_download_client_schema'),
   save_url_add: instance_path('radarr_download_client_add'),
-  save_url_edit: '/medias/' ~ current_slug('radarr') ~ '/radarr/clients-telechargement/__ID__/modifier',
+  save_url_edit: app.request.getBasePath() ~ '/medias/' ~ current_slug('radarr') ~ '/radarr/clients-telechargement/__ID__/modifier',
   test_url: instance_path('radarr_download_client_test')
 } %}
 {% endblock %}
@@ -117,6 +117,7 @@
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = '{{ app.request.getBasePath() }}';
   var I18N = {
     fallback_name: {{ 'media.arr_admin.download_clients.fallback_name'|trans|json_encode|raw }},
     test_success_title: {{ 'media.arr_admin.download_clients.test_success_title'|trans|json_encode|raw }},
@@ -183,7 +184,7 @@
   document.querySelectorAll('.btn-dc-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/clients-telechargement/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/clients-telechargement/' + btn.dataset.id + '/supprimer', {
         method: 'POST', headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'}, body: '{}',
       }).then(function(r) { return r.json(); }).then(function(data) {
         if (data.ok) location.reload();

--- a/symfony/templates/radarr/download_clients.html.twig
+++ b/symfony/templates/radarr/download_clients.html.twig
@@ -109,7 +109,7 @@
   modal_title_edit: 'media.arr_admin.download_clients.modal_title_edit'|trans,
   schema_url: instance_path('radarr_download_client_schema'),
   save_url_add: instance_path('radarr_download_client_add'),
-  save_url_edit: '/medias/' ~ current_slug('radarr') ~ '/radarr/clients-telechargement/__ID__/modifier',
+  save_url_edit: app.request.getBasePath() ~ '/medias/' ~ current_slug('radarr') ~ '/radarr/clients-telechargement/__ID__/modifier',
   test_url: instance_path('radarr_download_client_test')
 } %}
 {% endblock %}
@@ -117,6 +117,7 @@
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = window.BASE_PATH;
   var I18N = {
     fallback_name: {{ 'media.arr_admin.download_clients.fallback_name'|trans|json_encode|raw }},
     test_success_title: {{ 'media.arr_admin.download_clients.test_success_title'|trans|json_encode|raw }},
@@ -183,7 +184,7 @@
   document.querySelectorAll('.btn-dc-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/clients-telechargement/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/clients-telechargement/' + btn.dataset.id + '/supprimer', {
         method: 'POST', headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'}, body: '{}',
       }).then(function(r) { return r.json(); }).then(function(data) {
         if (data.ok) location.reload();

--- a/symfony/templates/radarr/exclusions.html.twig
+++ b/symfony/templates/radarr/exclusions.html.twig
@@ -119,6 +119,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = '{{ app.request.getBasePath() }}';
 var _I18N = {
   bulk_confirm_tpl: {{ 'media.arr_admin.exclusions.bulk_confirm_tpl'|trans({count: '__COUNT__'})|json_encode|raw }},
   delete_confirm: {{ 'media.arr_admin.exclusions.delete_confirm'|trans|json_encode|raw }},
@@ -173,7 +174,7 @@ if (bulkBtn) {
 document.querySelectorAll('.btn-excl-delete').forEach(function(btn) {
   btn.addEventListener('click', function() {
     if (!confirm(_I18N.delete_confirm)) return;
-    fetch('/medias/' + INSTANCE_SLUG + '/radarr/exclusions/' + btn.dataset.id + '/supprimer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/exclusions/' + btn.dataset.id + '/supprimer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}',

--- a/symfony/templates/radarr/exclusions.html.twig
+++ b/symfony/templates/radarr/exclusions.html.twig
@@ -119,6 +119,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = window.BASE_PATH;
 var _I18N = {
   bulk_confirm_tpl: {{ 'media.arr_admin.exclusions.bulk_confirm_tpl'|trans({count: '__COUNT__'})|json_encode|raw }},
   delete_confirm: {{ 'media.arr_admin.exclusions.delete_confirm'|trans|json_encode|raw }},
@@ -173,7 +174,7 @@ if (bulkBtn) {
 document.querySelectorAll('.btn-excl-delete').forEach(function(btn) {
   btn.addEventListener('click', function() {
     if (!confirm(_I18N.delete_confirm)) return;
-    fetch('/medias/' + INSTANCE_SLUG + '/radarr/exclusions/' + btn.dataset.id + '/supprimer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/exclusions/' + btn.dataset.id + '/supprimer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}',

--- a/symfony/templates/radarr/import_lists.html.twig
+++ b/symfony/templates/radarr/import_lists.html.twig
@@ -93,13 +93,14 @@
   modal_title_edit: 'media.arr_admin.import_lists.modal_title_edit'|trans,
   schema_url: instance_path('radarr_import_list_schema'),
   save_url_add: instance_path('radarr_import_list_add'),
-  save_url_edit: '/medias/' ~ current_slug('radarr') ~ '/radarr/listes-import/__ID__/modifier'
+  save_url_edit: app.request.getBasePath() ~ '/medias/' ~ current_slug('radarr') ~ '/radarr/listes-import/__ID__/modifier'
 } %}
 {% endblock %}
 
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = '{{ app.request.getBasePath() }}';
   var I18N = {
     error_delete: {{ 'media.arr_admin.import_lists.error_delete'|trans|json_encode|raw }},
     confirm_delete_tpl: {{ 'media.arr_admin.import_lists.confirm_delete_tpl'|trans({name: '__NAME__'})|json_encode|raw }}
@@ -117,7 +118,7 @@
   document.querySelectorAll('.btn-il-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/listes-import/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/listes-import/' + btn.dataset.id + '/supprimer', {
         method: 'POST', headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'}, body: '{}',
       }).then(function(r) { return r.json(); }).then(function(data) {
         if (data.ok) location.reload();

--- a/symfony/templates/radarr/import_lists.html.twig
+++ b/symfony/templates/radarr/import_lists.html.twig
@@ -93,13 +93,14 @@
   modal_title_edit: 'media.arr_admin.import_lists.modal_title_edit'|trans,
   schema_url: instance_path('radarr_import_list_schema'),
   save_url_add: instance_path('radarr_import_list_add'),
-  save_url_edit: '/medias/' ~ current_slug('radarr') ~ '/radarr/listes-import/__ID__/modifier'
+  save_url_edit: app.request.getBasePath() ~ '/medias/' ~ current_slug('radarr') ~ '/radarr/listes-import/__ID__/modifier'
 } %}
 {% endblock %}
 
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = window.BASE_PATH;
   var I18N = {
     error_delete: {{ 'media.arr_admin.import_lists.error_delete'|trans|json_encode|raw }},
     confirm_delete_tpl: {{ 'media.arr_admin.import_lists.confirm_delete_tpl'|trans({name: '__NAME__'})|json_encode|raw }}
@@ -117,7 +118,7 @@
   document.querySelectorAll('.btn-il-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/listes-import/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/listes-import/' + btn.dataset.id + '/supprimer', {
         method: 'POST', headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'}, body: '{}',
       }).then(function(r) { return r.json(); }).then(function(data) {
         if (data.ok) location.reload();

--- a/symfony/templates/radarr/indexers.html.twig
+++ b/symfony/templates/radarr/indexers.html.twig
@@ -97,7 +97,7 @@
   modal_title_edit: 'media.arr_admin.indexers.modal_title_edit'|trans,
   schema_url: instance_path('radarr_indexers_schema'),
   save_url_add: instance_path('radarr_indexer_add'),
-  save_url_edit: '/medias/' ~ current_slug('radarr') ~ '/radarr/indexeurs/__ID__/modifier',
+  save_url_edit: app.request.getBasePath() ~ '/medias/' ~ current_slug('radarr') ~ '/radarr/indexeurs/__ID__/modifier',
   test_url: instance_path('radarr_indexer_test')
 } %}
 {% endblock %}
@@ -105,6 +105,7 @@
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = '{{ app.request.getBasePath() }}';
   var I18N = {
     fallback_name: {{ 'media.arr_admin.indexers.fallback_name'|trans|json_encode|raw }},
     test_success_title: {{ 'media.arr_admin.indexers.test_success_title'|trans|json_encode|raw }},
@@ -147,7 +148,7 @@
         setTimeout(function() { btn.innerHTML = SVG_CHECK; btn.title = I18N.test_label; }, 3000);
         return;
       }
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/indexeurs/tester', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/indexeurs/tester', {
         method: 'POST', headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: JSON.stringify(indexer),
       }).then(function(r) { return r.json(); }).then(function(data) {
@@ -171,7 +172,7 @@
   document.querySelectorAll('.btn-idx-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/indexeurs/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/indexeurs/' + btn.dataset.id + '/supprimer', {
         method: 'POST', headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'}, body: '{}',
       }).then(function(r) { return r.json(); }).then(function(data) {
         if (data.ok) location.reload();

--- a/symfony/templates/radarr/indexers.html.twig
+++ b/symfony/templates/radarr/indexers.html.twig
@@ -97,7 +97,7 @@
   modal_title_edit: 'media.arr_admin.indexers.modal_title_edit'|trans,
   schema_url: instance_path('radarr_indexers_schema'),
   save_url_add: instance_path('radarr_indexer_add'),
-  save_url_edit: '/medias/' ~ current_slug('radarr') ~ '/radarr/indexeurs/__ID__/modifier',
+  save_url_edit: app.request.getBasePath() ~ '/medias/' ~ current_slug('radarr') ~ '/radarr/indexeurs/__ID__/modifier',
   test_url: instance_path('radarr_indexer_test')
 } %}
 {% endblock %}
@@ -105,6 +105,7 @@
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = window.BASE_PATH;
   var I18N = {
     fallback_name: {{ 'media.arr_admin.indexers.fallback_name'|trans|json_encode|raw }},
     test_success_title: {{ 'media.arr_admin.indexers.test_success_title'|trans|json_encode|raw }},
@@ -147,7 +148,7 @@
         setTimeout(function() { btn.innerHTML = SVG_CHECK; btn.title = I18N.test_label; }, 3000);
         return;
       }
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/indexeurs/tester', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/indexeurs/tester', {
         method: 'POST', headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: JSON.stringify(indexer),
       }).then(function(r) { return r.json(); }).then(function(data) {
@@ -171,7 +172,7 @@
   document.querySelectorAll('.btn-idx-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/indexeurs/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/indexeurs/' + btn.dataset.id + '/supprimer', {
         method: 'POST', headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'}, body: '{}',
       }).then(function(r) { return r.json(); }).then(function(data) {
         if (data.ok) location.reload();

--- a/symfony/templates/radarr/metadata.html.twig
+++ b/symfony/templates/radarr/metadata.html.twig
@@ -110,6 +110,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = '{{ app.request.getBasePath() }}';
   var META_I18N = {
     title_edit_tpl: {{ 'media.arr_admin.metadata.modal_title_edit_tpl'|trans({name: '__NAME__'})|json_encode|raw }},
     fields_title: {{ 'media.arr_admin.metadata.fields_title'|trans|json_encode|raw }},
@@ -199,7 +200,7 @@
     btn.addEventListener('click', function() {
       var id = btn.dataset.id;
       var enabled = btn.dataset.enabled === '1';
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/metadata/' + id + '/modifier', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/metadata/' + id + '/modifier', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: JSON.stringify({enable: !enabled}),
@@ -218,7 +219,7 @@
     payload.name = document.getElementById('meta-name').value.trim();
     payload.enable = document.getElementById('meta-enable').checked;
     payload.fields = collectFields();
-    fetch('/medias/' + INSTANCE_SLUG + '/radarr/metadata/' + payload.id + '/modifier', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/metadata/' + payload.id + '/modifier', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: JSON.stringify(payload),
@@ -237,7 +238,7 @@
   document.querySelectorAll('.btn-meta-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(META_I18N.delete_confirm_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/metadata/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/metadata/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}',

--- a/symfony/templates/radarr/metadata.html.twig
+++ b/symfony/templates/radarr/metadata.html.twig
@@ -110,6 +110,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = window.BASE_PATH;
   var META_I18N = {
     title_edit_tpl: {{ 'media.arr_admin.metadata.modal_title_edit_tpl'|trans({name: '__NAME__'})|json_encode|raw }},
     fields_title: {{ 'media.arr_admin.metadata.fields_title'|trans|json_encode|raw }},
@@ -199,7 +200,7 @@
     btn.addEventListener('click', function() {
       var id = btn.dataset.id;
       var enabled = btn.dataset.enabled === '1';
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/metadata/' + id + '/modifier', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/metadata/' + id + '/modifier', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: JSON.stringify({enable: !enabled}),
@@ -218,7 +219,7 @@
     payload.name = document.getElementById('meta-name').value.trim();
     payload.enable = document.getElementById('meta-enable').checked;
     payload.fields = collectFields();
-    fetch('/medias/' + INSTANCE_SLUG + '/radarr/metadata/' + payload.id + '/modifier', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/metadata/' + payload.id + '/modifier', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: JSON.stringify(payload),
@@ -237,7 +238,7 @@
   document.querySelectorAll('.btn-meta-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(META_I18N.delete_confirm_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/metadata/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/metadata/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}',

--- a/symfony/templates/radarr/notifications.html.twig
+++ b/symfony/templates/radarr/notifications.html.twig
@@ -105,7 +105,7 @@
   modal_title_edit: 'media.arr_admin.notifications.modal_title_edit'|trans,
   schema_url: instance_path('radarr_notifications_schema'),
   save_url_add: instance_path('radarr_notification_add'),
-  save_url_edit: '/medias/' ~ current_slug('radarr') ~ '/radarr/notifications/__ID__/modifier',
+  save_url_edit: app.request.getBasePath() ~ '/medias/' ~ current_slug('radarr') ~ '/radarr/notifications/__ID__/modifier',
   test_url: instance_path('radarr_notification_test_payload'),
   mode: 'notification'
 } %}
@@ -114,6 +114,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = '{{ app.request.getBasePath() }}';
   var I18N = {
     error_test: {{ 'media.arr_admin.notifications.error_test'|trans|json_encode|raw }},
     error_network: {{ 'media.arr_admin.notifications.error_network'|trans|json_encode|raw }},
@@ -139,7 +140,7 @@
       var origHTML = btn.innerHTML;
       btn.disabled = true;
       btn.innerHTML = SVG_SPIN;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/notifications/' + btn.dataset.id + '/tester', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/notifications/' + btn.dataset.id + '/tester', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}',
@@ -159,7 +160,7 @@
   document.querySelectorAll('.btn-notif-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/notifications/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/notifications/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}',

--- a/symfony/templates/radarr/notifications.html.twig
+++ b/symfony/templates/radarr/notifications.html.twig
@@ -105,7 +105,7 @@
   modal_title_edit: 'media.arr_admin.notifications.modal_title_edit'|trans,
   schema_url: instance_path('radarr_notifications_schema'),
   save_url_add: instance_path('radarr_notification_add'),
-  save_url_edit: '/medias/' ~ current_slug('radarr') ~ '/radarr/notifications/__ID__/modifier',
+  save_url_edit: app.request.getBasePath() ~ '/medias/' ~ current_slug('radarr') ~ '/radarr/notifications/__ID__/modifier',
   test_url: instance_path('radarr_notification_test_payload'),
   mode: 'notification'
 } %}
@@ -114,6 +114,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = window.BASE_PATH;
   var I18N = {
     error_test: {{ 'media.arr_admin.notifications.error_test'|trans|json_encode|raw }},
     error_network: {{ 'media.arr_admin.notifications.error_network'|trans|json_encode|raw }},
@@ -139,7 +140,7 @@
       var origHTML = btn.innerHTML;
       btn.disabled = true;
       btn.innerHTML = SVG_SPIN;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/notifications/' + btn.dataset.id + '/tester', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/notifications/' + btn.dataset.id + '/tester', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}',
@@ -159,7 +160,7 @@
   document.querySelectorAll('.btn-notif-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/notifications/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/notifications/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}',

--- a/symfony/templates/radarr/quality.html.twig
+++ b/symfony/templates/radarr/quality.html.twig
@@ -380,6 +380,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = '{{ app.request.getBasePath() }}';
 
 var I18N = {
   error_save_def: {{ 'media.arr_admin.quality.error_save_def'|trans|json_encode|raw }},
@@ -541,7 +542,7 @@ document.getElementById('btn-save-definitions').addEventListener('click', functi
     orig.maxSize       = parseFloat(wrap.querySelector('.range-max').value);
     payload.push(orig);
   });
-  fetch('/medias/' + INSTANCE_SLUG + '/radarr/qualite/definitions/sauvegarder', {
+  fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/qualite/definitions/sauvegarder', {
     method: 'POST',
     headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
     body: JSON.stringify(payload),
@@ -905,8 +906,8 @@ document.getElementById('btn-profile-save').addEventListener('click', function()
   }
 
   var url = isEdit
-    ? '/medias/' + INSTANCE_SLUG + '/radarr/qualite/profils/' + editId + '/modifier'
-    : '/medias/' + INSTANCE_SLUG + '/radarr/qualite/profils/ajouter';
+    ? BASE + '/medias/' + INSTANCE_SLUG + '/radarr/qualite/profils/' + editId + '/modifier'
+    : BASE + '/medias/' + INSTANCE_SLUG + '/radarr/qualite/profils/ajouter';
 
   fetch(url, {
     method: 'POST',
@@ -931,7 +932,7 @@ document.getElementById('btn-profile-delete-modal').addEventListener('click', fu
   var id = this.getAttribute('data-id');
   var name = this.getAttribute('data-name');
   if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', name))) return;
-  fetch('/medias/' + INSTANCE_SLUG + '/radarr/qualite/profils/' + id + '/supprimer', {
+  fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/qualite/profils/' + id + '/supprimer', {
     method: 'POST',
     headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
     body: '{}',
@@ -951,7 +952,7 @@ document.getElementById('btn-profile-delete-modal').addEventListener('click', fu
 document.querySelectorAll('.btn-profile-delete').forEach(function(btn) {
   btn.addEventListener('click', function() {
     if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-    fetch('/medias/' + INSTANCE_SLUG + '/radarr/qualite/profils/' + btn.dataset.id + '/supprimer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/qualite/profils/' + btn.dataset.id + '/supprimer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}',

--- a/symfony/templates/radarr/quality.html.twig
+++ b/symfony/templates/radarr/quality.html.twig
@@ -380,6 +380,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = window.BASE_PATH;
 
 var I18N = {
   error_save_def: {{ 'media.arr_admin.quality.error_save_def'|trans|json_encode|raw }},
@@ -541,7 +542,7 @@ document.getElementById('btn-save-definitions').addEventListener('click', functi
     orig.maxSize       = parseFloat(wrap.querySelector('.range-max').value);
     payload.push(orig);
   });
-  fetch('/medias/' + INSTANCE_SLUG + '/radarr/qualite/definitions/sauvegarder', {
+  fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/qualite/definitions/sauvegarder', {
     method: 'POST',
     headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
     body: JSON.stringify(payload),
@@ -905,8 +906,8 @@ document.getElementById('btn-profile-save').addEventListener('click', function()
   }
 
   var url = isEdit
-    ? '/medias/' + INSTANCE_SLUG + '/radarr/qualite/profils/' + editId + '/modifier'
-    : '/medias/' + INSTANCE_SLUG + '/radarr/qualite/profils/ajouter';
+    ? BASE + '/medias/' + INSTANCE_SLUG + '/radarr/qualite/profils/' + editId + '/modifier'
+    : BASE + '/medias/' + INSTANCE_SLUG + '/radarr/qualite/profils/ajouter';
 
   fetch(url, {
     method: 'POST',
@@ -931,7 +932,7 @@ document.getElementById('btn-profile-delete-modal').addEventListener('click', fu
   var id = this.getAttribute('data-id');
   var name = this.getAttribute('data-name');
   if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', name))) return;
-  fetch('/medias/' + INSTANCE_SLUG + '/radarr/qualite/profils/' + id + '/supprimer', {
+  fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/qualite/profils/' + id + '/supprimer', {
     method: 'POST',
     headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
     body: '{}',
@@ -951,7 +952,7 @@ document.getElementById('btn-profile-delete-modal').addEventListener('click', fu
 document.querySelectorAll('.btn-profile-delete').forEach(function(btn) {
   btn.addEventListener('click', function() {
     if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-    fetch('/medias/' + INSTANCE_SLUG + '/radarr/qualite/profils/' + btn.dataset.id + '/supprimer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/qualite/profils/' + btn.dataset.id + '/supprimer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}',

--- a/symfony/templates/radarr/remote_path_mappings.html.twig
+++ b/symfony/templates/radarr/remote_path_mappings.html.twig
@@ -99,6 +99,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = '{{ app.request.getBasePath() }}';
   var I18N = {
     modal_title_add: {{ 'media.arr_admin.remote_path_mappings.modal_title_add'|trans|json_encode|raw }},
     modal_title_edit: {{ 'media.arr_admin.remote_path_mappings.modal_title_edit'|trans|json_encode|raw }},
@@ -157,7 +158,7 @@
       return;
     }
     var payload = {host: host, remotePath: remotePath, localPath: localPath};
-    var url = id ? '/medias/' + INSTANCE_SLUG + '/radarr/chemins-distants/' + id + '/modifier' : '{{ instance_path("radarr_remote_path_mapping_add") }}';
+    var url = id ? BASE + '/medias/' + INSTANCE_SLUG + '/radarr/chemins-distants/' + id + '/modifier' : '{{ instance_path("radarr_remote_path_mapping_add") }}';
     if (id) payload.id = parseInt(id, 10);
     fetch(url, {
       method: 'POST',
@@ -172,7 +173,7 @@
   document.querySelectorAll('.btn-rpm-delete').forEach(function(btn) {
     btn.onclick = function() {
       if (!confirm(I18N.confirm_delete_tpl.replace('__HOST__', btn.dataset.host))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/chemins-distants/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/chemins-distants/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}',

--- a/symfony/templates/radarr/remote_path_mappings.html.twig
+++ b/symfony/templates/radarr/remote_path_mappings.html.twig
@@ -99,6 +99,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = window.BASE_PATH;
   var I18N = {
     modal_title_add: {{ 'media.arr_admin.remote_path_mappings.modal_title_add'|trans|json_encode|raw }},
     modal_title_edit: {{ 'media.arr_admin.remote_path_mappings.modal_title_edit'|trans|json_encode|raw }},
@@ -157,7 +158,7 @@
       return;
     }
     var payload = {host: host, remotePath: remotePath, localPath: localPath};
-    var url = id ? '/medias/' + INSTANCE_SLUG + '/radarr/chemins-distants/' + id + '/modifier' : '{{ instance_path("radarr_remote_path_mapping_add") }}';
+    var url = id ? BASE + '/medias/' + INSTANCE_SLUG + '/radarr/chemins-distants/' + id + '/modifier' : '{{ instance_path("radarr_remote_path_mapping_add") }}';
     if (id) payload.id = parseInt(id, 10);
     fetch(url, {
       method: 'POST',
@@ -172,7 +173,7 @@
   document.querySelectorAll('.btn-rpm-delete').forEach(function(btn) {
     btn.onclick = function() {
       if (!confirm(I18N.confirm_delete_tpl.replace('__HOST__', btn.dataset.host))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/radarr/chemins-distants/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/chemins-distants/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}',

--- a/symfony/templates/radarr/rename.html.twig
+++ b/symfony/templates/radarr/rename.html.twig
@@ -75,6 +75,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = '{{ app.request.getBasePath() }}';
 var _I18N = {
   select_movie_hint: {{ 'media.arr_admin.rename.select_movie_hint'|trans|json_encode|raw }},
   no_rename_needed: {{ 'media.arr_admin.rename.no_rename_needed'|trans|json_encode|raw }},
@@ -109,7 +110,7 @@ if (movieSelect) {
     document.getElementById('proposals-loading').classList.remove('d-none');
     document.getElementById('btn-rename-all').classList.add('d-none');
 
-    fetch('/medias/' + INSTANCE_SLUG + '/radarr/renommer/' + id + '/propositions', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/renommer/' + id + '/propositions', {
       headers: {'X-Requested-With': 'XMLHttpRequest'}
     }).then(function(r){ return r.json(); }).then(function(proposals){
       document.getElementById('proposals-loading').classList.add('d-none');
@@ -149,7 +150,7 @@ if (btnRenameAll) {
     progress.classList.remove('d-none');
     msg.textContent = _I18N.progress_starting;
 
-    fetch('/medias/' + INSTANCE_SLUG + '/radarr/renommer/' + currentMovieId + '/executer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/renommer/' + currentMovieId + '/executer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}'

--- a/symfony/templates/radarr/rename.html.twig
+++ b/symfony/templates/radarr/rename.html.twig
@@ -75,6 +75,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = window.BASE_PATH;
 var _I18N = {
   select_movie_hint: {{ 'media.arr_admin.rename.select_movie_hint'|trans|json_encode|raw }},
   no_rename_needed: {{ 'media.arr_admin.rename.no_rename_needed'|trans|json_encode|raw }},
@@ -109,7 +110,7 @@ if (movieSelect) {
     document.getElementById('proposals-loading').classList.remove('d-none');
     document.getElementById('btn-rename-all').classList.add('d-none');
 
-    fetch('/medias/' + INSTANCE_SLUG + '/radarr/renommer/' + id + '/propositions', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/renommer/' + id + '/propositions', {
       headers: {'X-Requested-With': 'XMLHttpRequest'}
     }).then(function(r){ return r.json(); }).then(function(proposals){
       document.getElementById('proposals-loading').classList.add('d-none');
@@ -149,7 +150,7 @@ if (btnRenameAll) {
     progress.classList.remove('d-none');
     msg.textContent = _I18N.progress_starting;
 
-    fetch('/medias/' + INSTANCE_SLUG + '/radarr/renommer/' + currentMovieId + '/executer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/renommer/' + currentMovieId + '/executer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}'

--- a/symfony/templates/radarr/root_folders.html.twig
+++ b/symfony/templates/radarr/root_folders.html.twig
@@ -76,6 +76,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = '{{ app.request.getBasePath() }}';
 var I18N = {
   errorPathRequired: {{ 'media.arr_admin.root_folders.error_path_required'|trans|json_encode|raw }},
   errorAdd: {{ 'media.arr_admin.root_folders.error_add_radarr'|trans|json_encode|raw }},
@@ -112,7 +113,7 @@ document.querySelectorAll('.btn-rf-delete').forEach(function(btn) {
   btn.addEventListener('click', function() {
     var msg = I18N.confirmDeleteTpl.replace('__PATH__', btn.dataset.path);
     if (!confirm(msg)) return;
-    fetch('/medias/' + INSTANCE_SLUG + '/radarr/dossiers-racine/' + btn.dataset.id + '/supprimer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/dossiers-racine/' + btn.dataset.id + '/supprimer', {
       method: 'POST', headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'}, body: '{}',
     }).then(function(r) { return r.json(); }).then(function(data) {
       if (data.ok) location.reload();

--- a/symfony/templates/radarr/root_folders.html.twig
+++ b/symfony/templates/radarr/root_folders.html.twig
@@ -76,6 +76,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = window.BASE_PATH;
 var I18N = {
   errorPathRequired: {{ 'media.arr_admin.root_folders.error_path_required'|trans|json_encode|raw }},
   errorAdd: {{ 'media.arr_admin.root_folders.error_add_radarr'|trans|json_encode|raw }},
@@ -112,7 +113,7 @@ document.querySelectorAll('.btn-rf-delete').forEach(function(btn) {
   btn.addEventListener('click', function() {
     var msg = I18N.confirmDeleteTpl.replace('__PATH__', btn.dataset.path);
     if (!confirm(msg)) return;
-    fetch('/medias/' + INSTANCE_SLUG + '/radarr/dossiers-racine/' + btn.dataset.id + '/supprimer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/dossiers-racine/' + btn.dataset.id + '/supprimer', {
       method: 'POST', headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'}, body: '{}',
     }).then(function(r) { return r.json(); }).then(function(data) {
       if (data.ok) location.reload();

--- a/symfony/templates/radarr/tags.html.twig
+++ b/symfony/templates/radarr/tags.html.twig
@@ -88,6 +88,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = '{{ app.request.getBasePath() }}';
 var TAGS_I18N = {
   created_tpl: {{ 'media.arr_admin.tags.created_tpl'|trans({label: '__LABEL__'})|json_encode|raw }},
   created_error: {{ 'media.arr_admin.tags.created_error'|trans|json_encode|raw }},
@@ -128,7 +129,7 @@ document.querySelectorAll('.btn-tag-rename').forEach(function(btn) {
     var currentLabel = btn.dataset.label;
     var newLabel = prompt(TAGS_I18N.rename_prompt, currentLabel);
     if (!newLabel || newLabel.trim() === '' || newLabel === currentLabel) return;
-    var r = await fetch('/medias/' + INSTANCE_SLUG + '/radarr/tags/' + btn.dataset.id + '/renommer', {
+    var r = await fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/tags/' + btn.dataset.id + '/renommer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: JSON.stringify({label: newLabel.trim()}),
@@ -146,7 +147,7 @@ document.querySelectorAll('.btn-tag-rename').forEach(function(btn) {
 document.querySelectorAll('.btn-tag-delete').forEach(function(btn) {
   btn.addEventListener('click', async function() {
     if (!confirm(TAGS_I18N.delete_confirm_tpl.replace('__LABEL__', btn.dataset.label))) return;
-    var r = await fetch('/medias/' + INSTANCE_SLUG + '/radarr/tags/' + btn.dataset.id + '/supprimer', {
+    var r = await fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/tags/' + btn.dataset.id + '/supprimer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}',

--- a/symfony/templates/radarr/tags.html.twig
+++ b/symfony/templates/radarr/tags.html.twig
@@ -88,6 +88,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = window.BASE_PATH;
 var TAGS_I18N = {
   created_tpl: {{ 'media.arr_admin.tags.created_tpl'|trans({label: '__LABEL__'})|json_encode|raw }},
   created_error: {{ 'media.arr_admin.tags.created_error'|trans|json_encode|raw }},
@@ -128,7 +129,7 @@ document.querySelectorAll('.btn-tag-rename').forEach(function(btn) {
     var currentLabel = btn.dataset.label;
     var newLabel = prompt(TAGS_I18N.rename_prompt, currentLabel);
     if (!newLabel || newLabel.trim() === '' || newLabel === currentLabel) return;
-    var r = await fetch('/medias/' + INSTANCE_SLUG + '/radarr/tags/' + btn.dataset.id + '/renommer', {
+    var r = await fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/tags/' + btn.dataset.id + '/renommer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: JSON.stringify({label: newLabel.trim()}),
@@ -146,7 +147,7 @@ document.querySelectorAll('.btn-tag-rename').forEach(function(btn) {
 document.querySelectorAll('.btn-tag-delete').forEach(function(btn) {
   btn.addEventListener('click', async function() {
     if (!confirm(TAGS_I18N.delete_confirm_tpl.replace('__LABEL__', btn.dataset.label))) return;
-    var r = await fetch('/medias/' + INSTANCE_SLUG + '/radarr/tags/' + btn.dataset.id + '/supprimer', {
+    var r = await fetch(BASE + '/medias/' + INSTANCE_SLUG + '/radarr/tags/' + btn.dataset.id + '/supprimer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}',

--- a/symfony/templates/setup/_layout.html.twig
+++ b/symfony/templates/setup/_layout.html.twig
@@ -480,6 +480,7 @@
   </div>
 
   <script>
+    var BASE = '{{ app.request.getBasePath() }}';
     document.getElementById('theme-toggle').addEventListener('click', function() {
       var current = document.documentElement.getAttribute('data-bs-theme');
       var next = current === 'dark' ? 'light' : 'dark';
@@ -537,7 +538,7 @@
           if (input) fd.append(f, input.value || '');
         });
 
-        fetch('/setup/test/' + svc, {
+        fetch(BASE + '/setup/test/' + svc, {
           method: 'POST',
           body: fd,
           credentials: 'same-origin',

--- a/symfony/templates/setup/_layout.html.twig
+++ b/symfony/templates/setup/_layout.html.twig
@@ -480,6 +480,7 @@
   </div>
 
   <script>
+    var BASE = window.BASE_PATH;
     document.getElementById('theme-toggle').addEventListener('click', function() {
       var current = document.documentElement.getAttribute('data-bs-theme');
       var next = current === 'dark' ? 'light' : 'dark';
@@ -537,7 +538,7 @@
           if (input) fd.append(f, input.value || '');
         });
 
-        fetch('/setup/test/' + svc, {
+        fetch(BASE + '/setup/test/' + svc, {
           method: 'POST',
           body: fd,
           credentials: 'same-origin',

--- a/symfony/templates/sonarr/auto_tags.html.twig
+++ b/symfony/templates/sonarr/auto_tags.html.twig
@@ -171,6 +171,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = '{{ app.request.getBasePath() }}';
   var _I18N = {
     modal_title_new: {{ 'media.arr_admin.auto_tags.modal_title_new'|trans|json_encode|raw }},
     modal_title_edit: {{ 'media.arr_admin.auto_tags.modal_title_edit_tpl'|trans({name: '__NAME__'})|json_encode|raw }},
@@ -387,7 +388,7 @@
     var url;
     if (editingItem) {
       payload.id = editingItem.id;
-      url = '/medias/' + INSTANCE_SLUG + '/sonarr/auto-tags/' + editingItem.id + '/modifier';
+      url = BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/auto-tags/' + editingItem.id + '/modifier';
     } else {
       url = {{ instance_path('sonarr_auto_tag_add')|json_encode|raw }};
     }
@@ -413,7 +414,7 @@
   document.querySelectorAll('.btn-at-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(_I18N.delete_confirm_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/auto-tags/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/auto-tags/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}'

--- a/symfony/templates/sonarr/auto_tags.html.twig
+++ b/symfony/templates/sonarr/auto_tags.html.twig
@@ -171,6 +171,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = window.BASE_PATH;
   var _I18N = {
     modal_title_new: {{ 'media.arr_admin.auto_tags.modal_title_new'|trans|json_encode|raw }},
     modal_title_edit: {{ 'media.arr_admin.auto_tags.modal_title_edit_tpl'|trans({name: '__NAME__'})|json_encode|raw }},
@@ -387,7 +388,7 @@
     var url;
     if (editingItem) {
       payload.id = editingItem.id;
-      url = '/medias/' + INSTANCE_SLUG + '/sonarr/auto-tags/' + editingItem.id + '/modifier';
+      url = BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/auto-tags/' + editingItem.id + '/modifier';
     } else {
       url = {{ instance_path('sonarr_auto_tag_add')|json_encode|raw }};
     }
@@ -413,7 +414,7 @@
   document.querySelectorAll('.btn-at-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(_I18N.delete_confirm_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/auto-tags/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/auto-tags/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}'

--- a/symfony/templates/sonarr/backups.html.twig
+++ b/symfony/templates/sonarr/backups.html.twig
@@ -125,6 +125,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = '{{ app.request.getBasePath() }}';
 var I18N = {
   starting: {{ 'media.arr_admin.backups.backup_starting'|trans|json_encode|raw }},
   statusTpl: {{ 'media.arr_admin.backups.backup_status_tpl'|trans({status: '__STATUS__'})|json_encode|raw }},
@@ -183,7 +184,7 @@ document.querySelectorAll('.btn-backup-delete').forEach(function(btn) {
   btn.onclick = function() {
     if (!confirm(I18N.confirmDelete)) return;
     var id = btn.dataset.id;
-    fetch('/medias/' + INSTANCE_SLUG + '/sonarr/sauvegardes/' + id + '/supprimer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/sauvegardes/' + id + '/supprimer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}'
@@ -216,7 +217,7 @@ if (btnConfirmRestore) {
     alertEl.classList.remove('d-none');
     msg.textContent = I18N.restoreInProgress;
 
-    fetch('/medias/' + INSTANCE_SLUG + '/sonarr/sauvegardes/' + pendingRestoreId + '/restaurer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/sauvegardes/' + pendingRestoreId + '/restaurer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}'

--- a/symfony/templates/sonarr/backups.html.twig
+++ b/symfony/templates/sonarr/backups.html.twig
@@ -125,6 +125,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = window.BASE_PATH;
 var I18N = {
   starting: {{ 'media.arr_admin.backups.backup_starting'|trans|json_encode|raw }},
   statusTpl: {{ 'media.arr_admin.backups.backup_status_tpl'|trans({status: '__STATUS__'})|json_encode|raw }},
@@ -183,7 +184,7 @@ document.querySelectorAll('.btn-backup-delete').forEach(function(btn) {
   btn.onclick = function() {
     if (!confirm(I18N.confirmDelete)) return;
     var id = btn.dataset.id;
-    fetch('/medias/' + INSTANCE_SLUG + '/sonarr/sauvegardes/' + id + '/supprimer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/sauvegardes/' + id + '/supprimer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}'
@@ -216,7 +217,7 @@ if (btnConfirmRestore) {
     alertEl.classList.remove('d-none');
     msg.textContent = I18N.restoreInProgress;
 
-    fetch('/medias/' + INSTANCE_SLUG + '/sonarr/sauvegardes/' + pendingRestoreId + '/restaurer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/sauvegardes/' + pendingRestoreId + '/restaurer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}'

--- a/symfony/templates/sonarr/commands.html.twig
+++ b/symfony/templates/sonarr/commands.html.twig
@@ -112,6 +112,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = '{{ app.request.getBasePath() }}';
 var I18N = {
   confirmCancelTpl: {{ 'media.arr_admin.commands.confirm_cancel_tpl'|trans({id: '__ID__'})|json_encode|raw }},
   cancelledTpl: {{ 'media.arr_admin.commands.cancelled_tpl'|trans({id: '__ID__'})|json_encode|raw }},
@@ -132,7 +133,7 @@ function bindCancelButtons() {
       var cmdId = btn.dataset.id;
       if (!confirm(I18N.confirmCancelTpl.replace('__ID__', cmdId))) return;
       btn.disabled = true;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/command/' + cmdId + '/annuler', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/command/' + cmdId + '/annuler', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}'

--- a/symfony/templates/sonarr/commands.html.twig
+++ b/symfony/templates/sonarr/commands.html.twig
@@ -112,6 +112,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = window.BASE_PATH;
 var I18N = {
   confirmCancelTpl: {{ 'media.arr_admin.commands.confirm_cancel_tpl'|trans({id: '__ID__'})|json_encode|raw }},
   cancelledTpl: {{ 'media.arr_admin.commands.cancelled_tpl'|trans({id: '__ID__'})|json_encode|raw }},
@@ -132,7 +133,7 @@ function bindCancelButtons() {
       var cmdId = btn.dataset.id;
       if (!confirm(I18N.confirmCancelTpl.replace('__ID__', cmdId))) return;
       btn.disabled = true;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/command/' + cmdId + '/annuler', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/command/' + cmdId + '/annuler', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}'

--- a/symfony/templates/sonarr/custom_filters.html.twig
+++ b/symfony/templates/sonarr/custom_filters.html.twig
@@ -109,6 +109,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = '{{ app.request.getBasePath() }}';
   var CF_I18N = {
     title_add: {{ 'media.arr_admin.custom_filters.modal_title_add'|trans|json_encode|raw }},
     title_edit: {{ 'media.arr_admin.custom_filters.modal_title_edit'|trans|json_encode|raw }},
@@ -165,7 +166,7 @@
     var filters;
     try { filters = JSON.parse(filtersRaw || '[]'); } catch(e) { showModalFeedback(CF_I18N.err_invalid_json, 'danger'); return; }
     var payload = {label: label, type: type, filters: filters};
-    var url = id ? '/medias/' + INSTANCE_SLUG + '/sonarr/filtres-personnalises/' + id + '/modifier' : '{{ instance_path("sonarr_custom_filter_add") }}';
+    var url = id ? BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/filtres-personnalises/' + id + '/modifier' : '{{ instance_path("sonarr_custom_filter_add") }}';
     if (id) payload.id = parseInt(id, 10);
     fetch(url, {
       method: 'POST',
@@ -180,7 +181,7 @@
   document.querySelectorAll('.btn-cf-delete').forEach(function(btn) {
     btn.onclick = function() {
       if (!confirm(CF_I18N.delete_confirm_tpl.replace('__LABEL__', btn.dataset.label))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/filtres-personnalises/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/filtres-personnalises/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}',

--- a/symfony/templates/sonarr/custom_filters.html.twig
+++ b/symfony/templates/sonarr/custom_filters.html.twig
@@ -109,6 +109,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = window.BASE_PATH;
   var CF_I18N = {
     title_add: {{ 'media.arr_admin.custom_filters.modal_title_add'|trans|json_encode|raw }},
     title_edit: {{ 'media.arr_admin.custom_filters.modal_title_edit'|trans|json_encode|raw }},
@@ -165,7 +166,7 @@
     var filters;
     try { filters = JSON.parse(filtersRaw || '[]'); } catch(e) { showModalFeedback(CF_I18N.err_invalid_json, 'danger'); return; }
     var payload = {label: label, type: type, filters: filters};
-    var url = id ? '/medias/' + INSTANCE_SLUG + '/sonarr/filtres-personnalises/' + id + '/modifier' : '{{ instance_path("sonarr_custom_filter_add") }}';
+    var url = id ? BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/filtres-personnalises/' + id + '/modifier' : '{{ instance_path("sonarr_custom_filter_add") }}';
     if (id) payload.id = parseInt(id, 10);
     fetch(url, {
       method: 'POST',
@@ -180,7 +181,7 @@
   document.querySelectorAll('.btn-cf-delete').forEach(function(btn) {
     btn.onclick = function() {
       if (!confirm(CF_I18N.delete_confirm_tpl.replace('__LABEL__', btn.dataset.label))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/filtres-personnalises/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/filtres-personnalises/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}',

--- a/symfony/templates/sonarr/custom_formats.html.twig
+++ b/symfony/templates/sonarr/custom_formats.html.twig
@@ -166,6 +166,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = '{{ app.request.getBasePath() }}';
   var I18N = {
     modal_new: {{ 'media.arr_admin.custom_formats.modal_new'|trans|json_encode|raw }},
     modal_edit_tpl: {{ 'media.arr_admin.custom_formats.modal_edit_tpl'|trans({name: '__NAME__'})|json_encode|raw }},
@@ -476,7 +477,7 @@
     try {
       var url = SAVE_URL;
       if (editingItem) {
-        url = '/medias/' + INSTANCE_SLUG + '/sonarr/formats/' + editingItem.id + '/modifier';
+        url = BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/formats/' + editingItem.id + '/modifier';
       }
       var r = await fetch(url, {
         method: 'POST',
@@ -504,7 +505,7 @@
     var btn = e.target.closest('.btn-cf-delete');
     if (!btn) return;
     if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-    fetch('/medias/' + INSTANCE_SLUG + '/sonarr/formats/' + btn.dataset.id + '/supprimer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/formats/' + btn.dataset.id + '/supprimer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}',

--- a/symfony/templates/sonarr/custom_formats.html.twig
+++ b/symfony/templates/sonarr/custom_formats.html.twig
@@ -166,6 +166,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = window.BASE_PATH;
   var I18N = {
     modal_new: {{ 'media.arr_admin.custom_formats.modal_new'|trans|json_encode|raw }},
     modal_edit_tpl: {{ 'media.arr_admin.custom_formats.modal_edit_tpl'|trans({name: '__NAME__'})|json_encode|raw }},
@@ -476,7 +477,7 @@
     try {
       var url = SAVE_URL;
       if (editingItem) {
-        url = '/medias/' + INSTANCE_SLUG + '/sonarr/formats/' + editingItem.id + '/modifier';
+        url = BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/formats/' + editingItem.id + '/modifier';
       }
       var r = await fetch(url, {
         method: 'POST',
@@ -504,7 +505,7 @@
     var btn = e.target.closest('.btn-cf-delete');
     if (!btn) return;
     if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-    fetch('/medias/' + INSTANCE_SLUG + '/sonarr/formats/' + btn.dataset.id + '/supprimer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/formats/' + btn.dataset.id + '/supprimer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}',

--- a/symfony/templates/sonarr/delay_profiles.html.twig
+++ b/symfony/templates/sonarr/delay_profiles.html.twig
@@ -192,6 +192,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = '{{ app.request.getBasePath() }}';
   var I18N = {
     modal_new: {{ 'media.arr_admin.delay_profiles.modal_new'|trans|json_encode|raw }},
     modal_edit_tpl: {{ 'media.arr_admin.delay_profiles.modal_edit_tpl'|trans({id: '__ID__'})|json_encode|raw }},
@@ -280,7 +281,7 @@
     if (editingItem) {
       payload.id = editingItem.id;
       payload.order = editingItem.order;
-      url = '/medias/' + INSTANCE_SLUG + '/sonarr/profils-delai/' + editingItem.id + '/modifier';
+      url = BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/profils-delai/' + editingItem.id + '/modifier';
     } else {
       url = {{ instance_path('sonarr_delay_profile_add')|json_encode|raw }};
     }
@@ -306,7 +307,7 @@
   document.querySelectorAll('.btn-delay-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(I18N.confirm_delete)) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/profils-delai/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/profils-delai/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}'

--- a/symfony/templates/sonarr/delay_profiles.html.twig
+++ b/symfony/templates/sonarr/delay_profiles.html.twig
@@ -192,6 +192,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = window.BASE_PATH;
   var I18N = {
     modal_new: {{ 'media.arr_admin.delay_profiles.modal_new'|trans|json_encode|raw }},
     modal_edit_tpl: {{ 'media.arr_admin.delay_profiles.modal_edit_tpl'|trans({id: '__ID__'})|json_encode|raw }},
@@ -280,7 +281,7 @@
     if (editingItem) {
       payload.id = editingItem.id;
       payload.order = editingItem.order;
-      url = '/medias/' + INSTANCE_SLUG + '/sonarr/profils-delai/' + editingItem.id + '/modifier';
+      url = BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/profils-delai/' + editingItem.id + '/modifier';
     } else {
       url = {{ instance_path('sonarr_delay_profile_add')|json_encode|raw }};
     }
@@ -306,7 +307,7 @@
   document.querySelectorAll('.btn-delay-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(I18N.confirm_delete)) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/profils-delai/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/profils-delai/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}'

--- a/symfony/templates/sonarr/download_clients.html.twig
+++ b/symfony/templates/sonarr/download_clients.html.twig
@@ -109,7 +109,7 @@
   modal_title_edit: 'media.arr_admin.download_clients.modal_title_edit'|trans,
   schema_url: instance_path('sonarr_download_client_schema'),
   save_url_add: instance_path('sonarr_download_client_add'),
-  save_url_edit: '/medias/' ~ current_slug('sonarr') ~ '/sonarr/clients-telechargement/__ID__/modifier',
+  save_url_edit: app.request.getBasePath() ~ '/medias/' ~ current_slug('sonarr') ~ '/sonarr/clients-telechargement/__ID__/modifier',
   test_url: instance_path('sonarr_download_client_test')
 } %}
 {% endblock %}
@@ -117,6 +117,7 @@
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = '{{ app.request.getBasePath() }}';
   var I18N = {
     fallback_name: {{ 'media.arr_admin.download_clients.fallback_name'|trans|json_encode|raw }},
     test_success_title: {{ 'media.arr_admin.download_clients.test_success_title'|trans|json_encode|raw }},
@@ -183,7 +184,7 @@
   document.querySelectorAll('.btn-dc-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/clients-telechargement/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/clients-telechargement/' + btn.dataset.id + '/supprimer', {
         method: 'POST', headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'}, body: '{}',
       }).then(function(r) { return r.json(); }).then(function(data) {
         if (data.ok) location.reload();

--- a/symfony/templates/sonarr/download_clients.html.twig
+++ b/symfony/templates/sonarr/download_clients.html.twig
@@ -109,7 +109,7 @@
   modal_title_edit: 'media.arr_admin.download_clients.modal_title_edit'|trans,
   schema_url: instance_path('sonarr_download_client_schema'),
   save_url_add: instance_path('sonarr_download_client_add'),
-  save_url_edit: '/medias/' ~ current_slug('sonarr') ~ '/sonarr/clients-telechargement/__ID__/modifier',
+  save_url_edit: app.request.getBasePath() ~ '/medias/' ~ current_slug('sonarr') ~ '/sonarr/clients-telechargement/__ID__/modifier',
   test_url: instance_path('sonarr_download_client_test')
 } %}
 {% endblock %}
@@ -117,6 +117,7 @@
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = window.BASE_PATH;
   var I18N = {
     fallback_name: {{ 'media.arr_admin.download_clients.fallback_name'|trans|json_encode|raw }},
     test_success_title: {{ 'media.arr_admin.download_clients.test_success_title'|trans|json_encode|raw }},
@@ -183,7 +184,7 @@
   document.querySelectorAll('.btn-dc-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/clients-telechargement/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/clients-telechargement/' + btn.dataset.id + '/supprimer', {
         method: 'POST', headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'}, body: '{}',
       }).then(function(r) { return r.json(); }).then(function(data) {
         if (data.ok) location.reload();

--- a/symfony/templates/sonarr/exclusions.html.twig
+++ b/symfony/templates/sonarr/exclusions.html.twig
@@ -70,6 +70,7 @@
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = '{{ app.request.getBasePath() }}';
   var _I18N = {
     delete_confirm: {{ 'media.arr_admin.exclusions.delete_confirm'|trans|json_encode|raw }}
   };
@@ -77,7 +78,7 @@
     btn.addEventListener('click', function() {
       if (!confirm(_I18N.delete_confirm)) return;
       btn.disabled = true;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/exclusions/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/exclusions/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
         body: '{}'

--- a/symfony/templates/sonarr/exclusions.html.twig
+++ b/symfony/templates/sonarr/exclusions.html.twig
@@ -70,6 +70,7 @@
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = window.BASE_PATH;
   var _I18N = {
     delete_confirm: {{ 'media.arr_admin.exclusions.delete_confirm'|trans|json_encode|raw }}
   };
@@ -77,7 +78,7 @@
     btn.addEventListener('click', function() {
       if (!confirm(_I18N.delete_confirm)) return;
       btn.disabled = true;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/exclusions/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/exclusions/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
         body: '{}'

--- a/symfony/templates/sonarr/import_lists.html.twig
+++ b/symfony/templates/sonarr/import_lists.html.twig
@@ -93,13 +93,14 @@
   modal_title_edit: 'media.arr_admin.import_lists.modal_title_edit'|trans,
   schema_url: instance_path('sonarr_import_list_schema'),
   save_url_add: instance_path('sonarr_import_list_add'),
-  save_url_edit: '/medias/' ~ current_slug('sonarr') ~ '/sonarr/listes-import/__ID__/modifier'
+  save_url_edit: app.request.getBasePath() ~ '/medias/' ~ current_slug('sonarr') ~ '/sonarr/listes-import/__ID__/modifier'
 } %}
 {% endblock %}
 
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = '{{ app.request.getBasePath() }}';
   var I18N = {
     error_delete: {{ 'media.arr_admin.import_lists.error_delete'|trans|json_encode|raw }},
     confirm_delete_tpl: {{ 'media.arr_admin.import_lists.confirm_delete_tpl'|trans({name: '__NAME__'})|json_encode|raw }}
@@ -117,7 +118,7 @@
   document.querySelectorAll('.btn-il-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/listes-import/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/listes-import/' + btn.dataset.id + '/supprimer', {
         method: 'POST', headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'}, body: '{}',
       }).then(function(r) { return r.json(); }).then(function(data) {
         if (data.ok) location.reload();

--- a/symfony/templates/sonarr/import_lists.html.twig
+++ b/symfony/templates/sonarr/import_lists.html.twig
@@ -93,13 +93,14 @@
   modal_title_edit: 'media.arr_admin.import_lists.modal_title_edit'|trans,
   schema_url: instance_path('sonarr_import_list_schema'),
   save_url_add: instance_path('sonarr_import_list_add'),
-  save_url_edit: '/medias/' ~ current_slug('sonarr') ~ '/sonarr/listes-import/__ID__/modifier'
+  save_url_edit: app.request.getBasePath() ~ '/medias/' ~ current_slug('sonarr') ~ '/sonarr/listes-import/__ID__/modifier'
 } %}
 {% endblock %}
 
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = window.BASE_PATH;
   var I18N = {
     error_delete: {{ 'media.arr_admin.import_lists.error_delete'|trans|json_encode|raw }},
     confirm_delete_tpl: {{ 'media.arr_admin.import_lists.confirm_delete_tpl'|trans({name: '__NAME__'})|json_encode|raw }}
@@ -117,7 +118,7 @@
   document.querySelectorAll('.btn-il-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/listes-import/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/listes-import/' + btn.dataset.id + '/supprimer', {
         method: 'POST', headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'}, body: '{}',
       }).then(function(r) { return r.json(); }).then(function(data) {
         if (data.ok) location.reload();

--- a/symfony/templates/sonarr/indexers.html.twig
+++ b/symfony/templates/sonarr/indexers.html.twig
@@ -97,7 +97,7 @@
   modal_title_edit: 'media.arr_admin.indexers.modal_title_edit'|trans,
   schema_url: instance_path('sonarr_indexers_schema'),
   save_url_add: instance_path('sonarr_indexer_add'),
-  save_url_edit: '/medias/' ~ current_slug('sonarr') ~ '/sonarr/indexeurs/__ID__/modifier',
+  save_url_edit: app.request.getBasePath() ~ '/medias/' ~ current_slug('sonarr') ~ '/sonarr/indexeurs/__ID__/modifier',
   test_url: instance_path('sonarr_indexer_test')
 } %}
 {% endblock %}
@@ -105,6 +105,7 @@
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = '{{ app.request.getBasePath() }}';
   var I18N = {
     fallback_name: {{ 'media.arr_admin.indexers.fallback_name'|trans|json_encode|raw }},
     test_success_title: {{ 'media.arr_admin.indexers.test_success_title'|trans|json_encode|raw }},
@@ -158,7 +159,7 @@
   document.querySelectorAll('.btn-idx-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/indexeurs/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/indexeurs/' + btn.dataset.id + '/supprimer', {
         method: 'POST', headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'}, body: '{}',
       }).then(function(r){ return r.json(); }).then(function(data) {
         if (data.ok) location.reload();

--- a/symfony/templates/sonarr/indexers.html.twig
+++ b/symfony/templates/sonarr/indexers.html.twig
@@ -97,7 +97,7 @@
   modal_title_edit: 'media.arr_admin.indexers.modal_title_edit'|trans,
   schema_url: instance_path('sonarr_indexers_schema'),
   save_url_add: instance_path('sonarr_indexer_add'),
-  save_url_edit: '/medias/' ~ current_slug('sonarr') ~ '/sonarr/indexeurs/__ID__/modifier',
+  save_url_edit: app.request.getBasePath() ~ '/medias/' ~ current_slug('sonarr') ~ '/sonarr/indexeurs/__ID__/modifier',
   test_url: instance_path('sonarr_indexer_test')
 } %}
 {% endblock %}
@@ -105,6 +105,7 @@
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = window.BASE_PATH;
   var I18N = {
     fallback_name: {{ 'media.arr_admin.indexers.fallback_name'|trans|json_encode|raw }},
     test_success_title: {{ 'media.arr_admin.indexers.test_success_title'|trans|json_encode|raw }},
@@ -158,7 +159,7 @@
   document.querySelectorAll('.btn-idx-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/indexeurs/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/indexeurs/' + btn.dataset.id + '/supprimer', {
         method: 'POST', headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'}, body: '{}',
       }).then(function(r){ return r.json(); }).then(function(data) {
         if (data.ok) location.reload();

--- a/symfony/templates/sonarr/library_import.html.twig
+++ b/symfony/templates/sonarr/library_import.html.twig
@@ -119,6 +119,7 @@
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = '{{ app.request.getBasePath() }}';
   var _I18N = {
     btn_scan: {{ 'media.arr_admin.library_import.btn_scan'|trans|json_encode|raw }},
     btn_scanning: {{ 'media.arr_admin.library_import.btn_scanning'|trans|json_encode|raw }},
@@ -184,7 +185,7 @@
     importableSeries = [];
     importAllBtn.disabled = true;
 
-    fetch('/medias/' + INSTANCE_SLUG + '/sonarr/import-bibliotheque/scan', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/import-bibliotheque/scan', {
       method: 'POST',
       headers: {'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
       body: JSON.stringify({folder: folder})
@@ -216,7 +217,7 @@
         tbody.appendChild(tr);
 
         // Auto lookup
-        fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/lookup?term=' + encodeURIComponent(f.name), {
+        fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/lookup?term=' + encodeURIComponent(f.name), {
           headers: {'X-Requested-With':'XMLHttpRequest'}
         }).then(function(r) { return r.json(); }).then(function(series) {
           var serieCell = tr.querySelector('.serie-cell');
@@ -331,7 +332,7 @@
       var statusCell = tr.querySelector('.status-cell');
       statusCell.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:14px;height:14px;"></span>';
 
-      fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/add', {
+      fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/add', {
         method: 'POST',
         headers: {'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
         body: JSON.stringify({

--- a/symfony/templates/sonarr/library_import.html.twig
+++ b/symfony/templates/sonarr/library_import.html.twig
@@ -119,6 +119,7 @@
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = window.BASE_PATH;
   var _I18N = {
     btn_scan: {{ 'media.arr_admin.library_import.btn_scan'|trans|json_encode|raw }},
     btn_scanning: {{ 'media.arr_admin.library_import.btn_scanning'|trans|json_encode|raw }},
@@ -184,7 +185,7 @@
     importableSeries = [];
     importAllBtn.disabled = true;
 
-    fetch('/medias/' + INSTANCE_SLUG + '/sonarr/import-bibliotheque/scan', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/import-bibliotheque/scan', {
       method: 'POST',
       headers: {'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
       body: JSON.stringify({folder: folder})
@@ -216,7 +217,7 @@
         tbody.appendChild(tr);
 
         // Auto lookup
-        fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/lookup?term=' + encodeURIComponent(f.name), {
+        fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/lookup?term=' + encodeURIComponent(f.name), {
           headers: {'X-Requested-With':'XMLHttpRequest'}
         }).then(function(r) { return r.json(); }).then(function(series) {
           var serieCell = tr.querySelector('.serie-cell');
@@ -331,7 +332,7 @@
       var statusCell = tr.querySelector('.status-cell');
       statusCell.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:14px;height:14px;"></span>';
 
-      fetch('/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/add', {
+      fetch(BASE + '/medias/' + (INSTANCE_SLUG || DEFAULT_SONARR_SLUG) + '/series/add', {
         method: 'POST',
         headers: {'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
         body: JSON.stringify({

--- a/symfony/templates/sonarr/media_management.html.twig
+++ b/symfony/templates/sonarr/media_management.html.twig
@@ -137,6 +137,7 @@
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = '{{ app.request.getBasePath() }}';
   var I18N = {
     namingSaved: {{ 'media.arr_admin.media_management.naming_saved'|trans|json_encode|raw }},
     mmSaved: {{ 'media.arr_admin.media_management.mm_saved'|trans|json_encode|raw }},
@@ -165,7 +166,7 @@
     new FormData(this).forEach(function(v, k) { data[k] = v; });
     data.renameEpisodes = !!document.getElementById('renameEpisodes').checked;
     data.multiEpisodeStyle = parseInt(data.multiEpisodeStyle || 0);
-    fetch('/medias/' + INSTANCE_SLUG + '/sonarr/gestion-medias/naming', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/gestion-medias/naming', {
       method: 'POST', headers: {'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
       body: JSON.stringify(data)
     }).then(function(r) { return r.json(); }).then(function(d) {
@@ -177,7 +178,7 @@
     var btn = this;
     btn.disabled = true;
     btn.textContent = I18N.loading;
-    fetch('/medias/' + INSTANCE_SLUG + '/sonarr/gestion-medias/naming/examples', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/gestion-medias/naming/examples', {
       headers: {'X-Requested-With':'XMLHttpRequest'}
     }).then(function(r) { return r.json(); }).then(function(data) {
       btn.disabled = false;
@@ -213,7 +214,7 @@
     data.createEmptySeriesFolders = !!document.getElementById('createEmptyFolders').checked;
     data.deleteEmptyFolders = !!document.getElementById('deleteEmptyFolders').checked;
     data.recycleBinCleanupDays = parseInt(data.recycleBinCleanupDays || 7);
-    fetch('/medias/' + INSTANCE_SLUG + '/sonarr/gestion-medias/mediamanagement', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/gestion-medias/mediamanagement', {
       method: 'POST', headers: {'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
       body: JSON.stringify(data)
     }).then(function(r) { return r.json(); }).then(function(d) {

--- a/symfony/templates/sonarr/media_management.html.twig
+++ b/symfony/templates/sonarr/media_management.html.twig
@@ -137,6 +137,7 @@
 {% block javascripts %}
 <script>
 (function() {
+  var BASE = window.BASE_PATH;
   var I18N = {
     namingSaved: {{ 'media.arr_admin.media_management.naming_saved'|trans|json_encode|raw }},
     mmSaved: {{ 'media.arr_admin.media_management.mm_saved'|trans|json_encode|raw }},
@@ -165,7 +166,7 @@
     new FormData(this).forEach(function(v, k) { data[k] = v; });
     data.renameEpisodes = !!document.getElementById('renameEpisodes').checked;
     data.multiEpisodeStyle = parseInt(data.multiEpisodeStyle || 0);
-    fetch('/medias/' + INSTANCE_SLUG + '/sonarr/gestion-medias/naming', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/gestion-medias/naming', {
       method: 'POST', headers: {'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
       body: JSON.stringify(data)
     }).then(function(r) { return r.json(); }).then(function(d) {
@@ -177,7 +178,7 @@
     var btn = this;
     btn.disabled = true;
     btn.textContent = I18N.loading;
-    fetch('/medias/' + INSTANCE_SLUG + '/sonarr/gestion-medias/naming/examples', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/gestion-medias/naming/examples', {
       headers: {'X-Requested-With':'XMLHttpRequest'}
     }).then(function(r) { return r.json(); }).then(function(data) {
       btn.disabled = false;
@@ -213,7 +214,7 @@
     data.createEmptySeriesFolders = !!document.getElementById('createEmptyFolders').checked;
     data.deleteEmptyFolders = !!document.getElementById('deleteEmptyFolders').checked;
     data.recycleBinCleanupDays = parseInt(data.recycleBinCleanupDays || 7);
-    fetch('/medias/' + INSTANCE_SLUG + '/sonarr/gestion-medias/mediamanagement', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/gestion-medias/mediamanagement', {
       method: 'POST', headers: {'Content-Type':'application/json','X-Requested-With':'XMLHttpRequest'},
       body: JSON.stringify(data)
     }).then(function(r) { return r.json(); }).then(function(d) {

--- a/symfony/templates/sonarr/metadata.html.twig
+++ b/symfony/templates/sonarr/metadata.html.twig
@@ -110,6 +110,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = '{{ app.request.getBasePath() }}';
   var META_I18N = {
     title_edit_tpl: {{ 'media.arr_admin.metadata.modal_title_edit_tpl'|trans({name: '__NAME__'})|json_encode|raw }},
     fields_title: {{ 'media.arr_admin.metadata.fields_title'|trans|json_encode|raw }},
@@ -199,7 +200,7 @@
     btn.addEventListener('click', function() {
       var id = btn.dataset.id;
       var enabled = btn.dataset.enabled === '1';
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/metadata/' + id + '/modifier', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/metadata/' + id + '/modifier', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: JSON.stringify({enable: !enabled}),
@@ -218,7 +219,7 @@
     payload.name = document.getElementById('meta-name').value.trim();
     payload.enable = document.getElementById('meta-enable').checked;
     payload.fields = collectFields();
-    fetch('/medias/' + INSTANCE_SLUG + '/sonarr/metadata/' + payload.id + '/modifier', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/metadata/' + payload.id + '/modifier', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: JSON.stringify(payload),
@@ -237,7 +238,7 @@
   document.querySelectorAll('.btn-meta-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(META_I18N.delete_confirm_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/metadata/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/metadata/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}',

--- a/symfony/templates/sonarr/metadata.html.twig
+++ b/symfony/templates/sonarr/metadata.html.twig
@@ -110,6 +110,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = window.BASE_PATH;
   var META_I18N = {
     title_edit_tpl: {{ 'media.arr_admin.metadata.modal_title_edit_tpl'|trans({name: '__NAME__'})|json_encode|raw }},
     fields_title: {{ 'media.arr_admin.metadata.fields_title'|trans|json_encode|raw }},
@@ -199,7 +200,7 @@
     btn.addEventListener('click', function() {
       var id = btn.dataset.id;
       var enabled = btn.dataset.enabled === '1';
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/metadata/' + id + '/modifier', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/metadata/' + id + '/modifier', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: JSON.stringify({enable: !enabled}),
@@ -218,7 +219,7 @@
     payload.name = document.getElementById('meta-name').value.trim();
     payload.enable = document.getElementById('meta-enable').checked;
     payload.fields = collectFields();
-    fetch('/medias/' + INSTANCE_SLUG + '/sonarr/metadata/' + payload.id + '/modifier', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/metadata/' + payload.id + '/modifier', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: JSON.stringify(payload),
@@ -237,7 +238,7 @@
   document.querySelectorAll('.btn-meta-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(META_I18N.delete_confirm_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/metadata/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/metadata/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}',

--- a/symfony/templates/sonarr/notifications.html.twig
+++ b/symfony/templates/sonarr/notifications.html.twig
@@ -105,7 +105,7 @@
   modal_title_edit: 'media.arr_admin.notifications.modal_title_edit'|trans,
   schema_url: instance_path('sonarr_notifications_schema'),
   save_url_add: instance_path('sonarr_notification_add'),
-  save_url_edit: '/medias/' ~ current_slug('sonarr') ~ '/sonarr/notifications/__ID__/modifier',
+  save_url_edit: app.request.getBasePath() ~ '/medias/' ~ current_slug('sonarr') ~ '/sonarr/notifications/__ID__/modifier',
   test_url: instance_path('sonarr_notification_test_payload'),
   mode: 'notification'
 } %}
@@ -114,6 +114,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = '{{ app.request.getBasePath() }}';
   var I18N = {
     error_test: {{ 'media.arr_admin.notifications.error_test'|trans|json_encode|raw }},
     error_network: {{ 'media.arr_admin.notifications.error_network'|trans|json_encode|raw }},
@@ -139,7 +140,7 @@
       var origHTML = btn.innerHTML;
       btn.disabled = true;
       btn.innerHTML = SVG_SPIN;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/notifications/' + btn.dataset.id + '/tester', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/notifications/' + btn.dataset.id + '/tester', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}',
@@ -159,7 +160,7 @@
   document.querySelectorAll('.btn-notif-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/notifications/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/notifications/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}',

--- a/symfony/templates/sonarr/notifications.html.twig
+++ b/symfony/templates/sonarr/notifications.html.twig
@@ -105,7 +105,7 @@
   modal_title_edit: 'media.arr_admin.notifications.modal_title_edit'|trans,
   schema_url: instance_path('sonarr_notifications_schema'),
   save_url_add: instance_path('sonarr_notification_add'),
-  save_url_edit: '/medias/' ~ current_slug('sonarr') ~ '/sonarr/notifications/__ID__/modifier',
+  save_url_edit: app.request.getBasePath() ~ '/medias/' ~ current_slug('sonarr') ~ '/sonarr/notifications/__ID__/modifier',
   test_url: instance_path('sonarr_notification_test_payload'),
   mode: 'notification'
 } %}
@@ -114,6 +114,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = window.BASE_PATH;
   var I18N = {
     error_test: {{ 'media.arr_admin.notifications.error_test'|trans|json_encode|raw }},
     error_network: {{ 'media.arr_admin.notifications.error_network'|trans|json_encode|raw }},
@@ -139,7 +140,7 @@
       var origHTML = btn.innerHTML;
       btn.disabled = true;
       btn.innerHTML = SVG_SPIN;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/notifications/' + btn.dataset.id + '/tester', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/notifications/' + btn.dataset.id + '/tester', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}',
@@ -159,7 +160,7 @@
   document.querySelectorAll('.btn-notif-delete').forEach(function(btn) {
     btn.addEventListener('click', function() {
       if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/notifications/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/notifications/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}',

--- a/symfony/templates/sonarr/quality.html.twig
+++ b/symfony/templates/sonarr/quality.html.twig
@@ -380,6 +380,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = '{{ app.request.getBasePath() }}';
 
 var I18N = {
   error_save_def: {{ 'media.arr_admin.quality.error_save_def'|trans|json_encode|raw }},
@@ -541,7 +542,7 @@ document.getElementById('btn-save-definitions').addEventListener('click', functi
     orig.maxSize       = parseFloat(wrap.querySelector('.range-max').value);
     payload.push(orig);
   });
-  fetch('/medias/' + INSTANCE_SLUG + '/sonarr/qualite/definitions/sauvegarder', {
+  fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/qualite/definitions/sauvegarder', {
     method: 'POST',
     headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
     body: JSON.stringify(payload),
@@ -905,8 +906,8 @@ document.getElementById('btn-profile-save').addEventListener('click', function()
   }
 
   var url = isEdit
-    ? '/medias/' + INSTANCE_SLUG + '/sonarr/qualite/profils/' + editId + '/modifier'
-    : '/medias/' + INSTANCE_SLUG + '/sonarr/qualite/profils/ajouter';
+    ? BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/qualite/profils/' + editId + '/modifier'
+    : BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/qualite/profils/ajouter';
 
   fetch(url, {
     method: 'POST',
@@ -931,7 +932,7 @@ document.getElementById('btn-profile-delete-modal').addEventListener('click', fu
   var id = this.getAttribute('data-id');
   var name = this.getAttribute('data-name');
   if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', name))) return;
-  fetch('/medias/' + INSTANCE_SLUG + '/sonarr/qualite/profils/' + id + '/supprimer', {
+  fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/qualite/profils/' + id + '/supprimer', {
     method: 'POST',
     headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
     body: '{}',
@@ -951,7 +952,7 @@ document.getElementById('btn-profile-delete-modal').addEventListener('click', fu
 document.querySelectorAll('.btn-profile-delete').forEach(function(btn) {
   btn.addEventListener('click', function() {
     if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-    fetch('/medias/' + INSTANCE_SLUG + '/sonarr/qualite/profils/' + btn.dataset.id + '/supprimer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/qualite/profils/' + btn.dataset.id + '/supprimer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}',

--- a/symfony/templates/sonarr/quality.html.twig
+++ b/symfony/templates/sonarr/quality.html.twig
@@ -380,6 +380,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = window.BASE_PATH;
 
 var I18N = {
   error_save_def: {{ 'media.arr_admin.quality.error_save_def'|trans|json_encode|raw }},
@@ -541,7 +542,7 @@ document.getElementById('btn-save-definitions').addEventListener('click', functi
     orig.maxSize       = parseFloat(wrap.querySelector('.range-max').value);
     payload.push(orig);
   });
-  fetch('/medias/' + INSTANCE_SLUG + '/sonarr/qualite/definitions/sauvegarder', {
+  fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/qualite/definitions/sauvegarder', {
     method: 'POST',
     headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
     body: JSON.stringify(payload),
@@ -905,8 +906,8 @@ document.getElementById('btn-profile-save').addEventListener('click', function()
   }
 
   var url = isEdit
-    ? '/medias/' + INSTANCE_SLUG + '/sonarr/qualite/profils/' + editId + '/modifier'
-    : '/medias/' + INSTANCE_SLUG + '/sonarr/qualite/profils/ajouter';
+    ? BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/qualite/profils/' + editId + '/modifier'
+    : BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/qualite/profils/ajouter';
 
   fetch(url, {
     method: 'POST',
@@ -931,7 +932,7 @@ document.getElementById('btn-profile-delete-modal').addEventListener('click', fu
   var id = this.getAttribute('data-id');
   var name = this.getAttribute('data-name');
   if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', name))) return;
-  fetch('/medias/' + INSTANCE_SLUG + '/sonarr/qualite/profils/' + id + '/supprimer', {
+  fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/qualite/profils/' + id + '/supprimer', {
     method: 'POST',
     headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
     body: '{}',
@@ -951,7 +952,7 @@ document.getElementById('btn-profile-delete-modal').addEventListener('click', fu
 document.querySelectorAll('.btn-profile-delete').forEach(function(btn) {
   btn.addEventListener('click', function() {
     if (!confirm(I18N.confirm_delete_tpl.replace('__NAME__', btn.dataset.name))) return;
-    fetch('/medias/' + INSTANCE_SLUG + '/sonarr/qualite/profils/' + btn.dataset.id + '/supprimer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/qualite/profils/' + btn.dataset.id + '/supprimer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}',

--- a/symfony/templates/sonarr/remote_path_mappings.html.twig
+++ b/symfony/templates/sonarr/remote_path_mappings.html.twig
@@ -99,6 +99,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = '{{ app.request.getBasePath() }}';
   var I18N = {
     modal_title_add: {{ 'media.arr_admin.remote_path_mappings.modal_title_add'|trans|json_encode|raw }},
     modal_title_edit: {{ 'media.arr_admin.remote_path_mappings.modal_title_edit'|trans|json_encode|raw }},
@@ -157,7 +158,7 @@
       return;
     }
     var payload = {host: host, remotePath: remotePath, localPath: localPath};
-    var url = id ? '/medias/' + INSTANCE_SLUG + '/sonarr/chemins-distants/' + id + '/modifier' : '{{ instance_path("radarr_remote_path_mapping_add") }}';
+    var url = id ? BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/chemins-distants/' + id + '/modifier' : '{{ instance_path("radarr_remote_path_mapping_add") }}';
     if (id) payload.id = parseInt(id, 10);
     fetch(url, {
       method: 'POST',
@@ -172,7 +173,7 @@
   document.querySelectorAll('.btn-rpm-delete').forEach(function(btn) {
     btn.onclick = function() {
       if (!confirm(I18N.confirm_delete_tpl.replace('__HOST__', btn.dataset.host))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/chemins-distants/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/chemins-distants/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}',

--- a/symfony/templates/sonarr/remote_path_mappings.html.twig
+++ b/symfony/templates/sonarr/remote_path_mappings.html.twig
@@ -99,6 +99,7 @@
 {% block javascripts %}
 <script>
 (function(){
+  var BASE = window.BASE_PATH;
   var I18N = {
     modal_title_add: {{ 'media.arr_admin.remote_path_mappings.modal_title_add'|trans|json_encode|raw }},
     modal_title_edit: {{ 'media.arr_admin.remote_path_mappings.modal_title_edit'|trans|json_encode|raw }},
@@ -157,7 +158,7 @@
       return;
     }
     var payload = {host: host, remotePath: remotePath, localPath: localPath};
-    var url = id ? '/medias/' + INSTANCE_SLUG + '/sonarr/chemins-distants/' + id + '/modifier' : '{{ instance_path("radarr_remote_path_mapping_add") }}';
+    var url = id ? BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/chemins-distants/' + id + '/modifier' : '{{ instance_path("radarr_remote_path_mapping_add") }}';
     if (id) payload.id = parseInt(id, 10);
     fetch(url, {
       method: 'POST',
@@ -172,7 +173,7 @@
   document.querySelectorAll('.btn-rpm-delete').forEach(function(btn) {
     btn.onclick = function() {
       if (!confirm(I18N.confirm_delete_tpl.replace('__HOST__', btn.dataset.host))) return;
-      fetch('/medias/' + INSTANCE_SLUG + '/sonarr/chemins-distants/' + btn.dataset.id + '/supprimer', {
+      fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/chemins-distants/' + btn.dataset.id + '/supprimer', {
         method: 'POST',
         headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
         body: '{}',

--- a/symfony/templates/sonarr/root_folders.html.twig
+++ b/symfony/templates/sonarr/root_folders.html.twig
@@ -76,6 +76,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = '{{ app.request.getBasePath() }}';
 var I18N = {
   errorPathRequired: {{ 'media.arr_admin.root_folders.error_path_required'|trans|json_encode|raw }},
   errorAdd: {{ 'media.arr_admin.root_folders.error_add_sonarr'|trans|json_encode|raw }},
@@ -112,7 +113,7 @@ document.querySelectorAll('.btn-rf-delete').forEach(function(btn) {
   btn.addEventListener('click', function() {
     var msg = I18N.confirmDeleteTpl.replace('__PATH__', btn.dataset.path);
     if (!confirm(msg)) return;
-    fetch('/medias/' + INSTANCE_SLUG + '/sonarr/dossiers-racine/' + btn.dataset.id + '/supprimer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/dossiers-racine/' + btn.dataset.id + '/supprimer', {
       method: 'POST', headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'}, body: '{}',
     }).then(function(r) { return r.json(); }).then(function(data) {
       if (data.ok) location.reload();

--- a/symfony/templates/sonarr/root_folders.html.twig
+++ b/symfony/templates/sonarr/root_folders.html.twig
@@ -76,6 +76,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = window.BASE_PATH;
 var I18N = {
   errorPathRequired: {{ 'media.arr_admin.root_folders.error_path_required'|trans|json_encode|raw }},
   errorAdd: {{ 'media.arr_admin.root_folders.error_add_sonarr'|trans|json_encode|raw }},
@@ -112,7 +113,7 @@ document.querySelectorAll('.btn-rf-delete').forEach(function(btn) {
   btn.addEventListener('click', function() {
     var msg = I18N.confirmDeleteTpl.replace('__PATH__', btn.dataset.path);
     if (!confirm(msg)) return;
-    fetch('/medias/' + INSTANCE_SLUG + '/sonarr/dossiers-racine/' + btn.dataset.id + '/supprimer', {
+    fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/dossiers-racine/' + btn.dataset.id + '/supprimer', {
       method: 'POST', headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'}, body: '{}',
     }).then(function(r) { return r.json(); }).then(function(data) {
       if (data.ok) location.reload();

--- a/symfony/templates/sonarr/tags.html.twig
+++ b/symfony/templates/sonarr/tags.html.twig
@@ -88,6 +88,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = '{{ app.request.getBasePath() }}';
 var TAGS_I18N = {
   created_tpl: {{ 'media.arr_admin.tags.created_tpl'|trans({label: '__LABEL__'})|json_encode|raw }},
   created_error: {{ 'media.arr_admin.tags.created_error'|trans|json_encode|raw }},
@@ -128,7 +129,7 @@ document.querySelectorAll('.btn-tag-rename').forEach(function(btn) {
     var currentLabel = btn.dataset.label;
     var newLabel = prompt(TAGS_I18N.rename_prompt, currentLabel);
     if (!newLabel || newLabel.trim() === '' || newLabel === currentLabel) return;
-    var r = await fetch('/medias/' + INSTANCE_SLUG + '/sonarr/tags/' + btn.dataset.id + '/renommer', {
+    var r = await fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/tags/' + btn.dataset.id + '/renommer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: JSON.stringify({label: newLabel.trim()}),
@@ -146,7 +147,7 @@ document.querySelectorAll('.btn-tag-rename').forEach(function(btn) {
 document.querySelectorAll('.btn-tag-delete').forEach(function(btn) {
   btn.addEventListener('click', async function() {
     if (!confirm(TAGS_I18N.delete_confirm_tpl.replace('__LABEL__', btn.dataset.label))) return;
-    var r = await fetch('/medias/' + INSTANCE_SLUG + '/sonarr/tags/' + btn.dataset.id + '/supprimer', {
+    var r = await fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/tags/' + btn.dataset.id + '/supprimer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}',

--- a/symfony/templates/sonarr/tags.html.twig
+++ b/symfony/templates/sonarr/tags.html.twig
@@ -88,6 +88,7 @@
 {% block javascripts %}
 <script>
 (function(){
+var BASE = window.BASE_PATH;
 var TAGS_I18N = {
   created_tpl: {{ 'media.arr_admin.tags.created_tpl'|trans({label: '__LABEL__'})|json_encode|raw }},
   created_error: {{ 'media.arr_admin.tags.created_error'|trans|json_encode|raw }},
@@ -128,7 +129,7 @@ document.querySelectorAll('.btn-tag-rename').forEach(function(btn) {
     var currentLabel = btn.dataset.label;
     var newLabel = prompt(TAGS_I18N.rename_prompt, currentLabel);
     if (!newLabel || newLabel.trim() === '' || newLabel === currentLabel) return;
-    var r = await fetch('/medias/' + INSTANCE_SLUG + '/sonarr/tags/' + btn.dataset.id + '/renommer', {
+    var r = await fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/tags/' + btn.dataset.id + '/renommer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: JSON.stringify({label: newLabel.trim()}),
@@ -146,7 +147,7 @@ document.querySelectorAll('.btn-tag-rename').forEach(function(btn) {
 document.querySelectorAll('.btn-tag-delete').forEach(function(btn) {
   btn.addEventListener('click', async function() {
     if (!confirm(TAGS_I18N.delete_confirm_tpl.replace('__LABEL__', btn.dataset.label))) return;
-    var r = await fetch('/medias/' + INSTANCE_SLUG + '/sonarr/tags/' + btn.dataset.id + '/supprimer', {
+    var r = await fetch(BASE + '/medias/' + INSTANCE_SLUG + '/sonarr/tags/' + btn.dataset.id + '/supprimer', {
       method: 'POST',
       headers: {'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest'},
       body: '{}',

--- a/symfony/templates/tautulli/index.html.twig
+++ b/symfony/templates/tautulli/index.html.twig
@@ -187,6 +187,7 @@
 <script src="{{ asset('static/chart/chart.umd.min.js') }}"></script>
 <script>
 (function () {
+  var BASE = '{{ app.request.getBasePath() }}';
   var HISTORY_PAGE = 25;
   var state = { range: 30, metric: 'plays', userId: '' };
   var playsMode = 'media';
@@ -218,16 +219,16 @@
 
   function refreshNow() {
     if (document.hidden) return;
-    loadFragment('/tautulli/api/now-playing', frag('[data-tautulli-now]'));
+    loadFragment(BASE + '/tautulli/api/now-playing', frag('[data-tautulli-now]'));
   }
   function refreshStats() {
-    loadFragment('/tautulli/api/stats?' + qs(), frag('[data-tautulli-stats]'));
+    loadFragment(BASE + '/tautulli/api/stats?' + qs(), frag('[data-tautulli-stats]'));
   }
   function refreshLibraries() {
-    loadFragment('/tautulli/api/libraries', frag('[data-tautulli-libraries]'));
+    loadFragment(BASE + '/tautulli/api/libraries', frag('[data-tautulli-libraries]'));
   }
   function refreshUsers() {
-    loadFragment('/tautulli/api/users', frag('[data-tautulli-users]')).then(function () {
+    loadFragment(BASE + '/tautulli/api/users', frag('[data-tautulli-users]')).then(function () {
       var box = frag('[data-tautulli-users]');
       if (!box) return;
       box.querySelectorAll('[data-tautulli-secs]').forEach(function (el) {
@@ -238,7 +239,7 @@
 
   function loadHistory(append) {
     if (!append) historyStart = 0;
-    var url = '/tautulli/api/history?length=' + HISTORY_PAGE + '&start=' + historyStart + (state.userId ? '&user=' + encodeURIComponent(state.userId) : '');
+    var url = BASE + '/tautulli/api/history?length=' + HISTORY_PAGE + '&start=' + historyStart + (state.userId ? '&user=' + encodeURIComponent(state.userId) : '');
     fetch(url, { headers: { 'X-Requested-With': 'fetch' }, credentials: 'same-origin' })
       .then(function (r) { return r.ok ? r.text() : ''; })
       .then(function (html) {
@@ -304,29 +305,29 @@
   }
 
   function refreshPlays() {
-    drawStackedBar({ id: 'tautulli-plays', url: '/tautulli/api/plays?' + qs('mode=' + playsMode), wrap: '#tautulli-plays-wrap', empty: '[data-tautulli-plays-empty]' });
+    drawStackedBar({ id: 'tautulli-plays', url: BASE + '/tautulli/api/plays?' + qs('mode=' + playsMode), wrap: '#tautulli-plays-wrap', empty: '[data-tautulli-plays-empty]' });
   }
   function refreshActivityHour() {
-    drawStackedBar({ id: 'tautulli-activity-hour', url: '/tautulli/api/activity-hour?' + qs(), wrap: '#tautulli-activity-hour-wrap', empty: '[data-tautulli-activity-hour-empty]' });
+    drawStackedBar({ id: 'tautulli-activity-hour', url: BASE + '/tautulli/api/activity-hour?' + qs(), wrap: '#tautulli-activity-hour-wrap', empty: '[data-tautulli-activity-hour-empty]' });
   }
   function refreshActivityDow() {
-    drawStackedBar({ id: 'tautulli-activity-dow', url: '/tautulli/api/activity-dow?' + qs(), wrap: '#tautulli-activity-dow-wrap', empty: '[data-tautulli-activity-dow-empty]' });
+    drawStackedBar({ id: 'tautulli-activity-dow', url: BASE + '/tautulli/api/activity-dow?' + qs(), wrap: '#tautulli-activity-dow-wrap', empty: '[data-tautulli-activity-dow-empty]' });
   }
   function refreshClients() {
-    drawStackedBar({ id: 'tautulli-clients-stream-type', url: '/tautulli/api/clients-stream-type?' + qs(), wrap: '#tautulli-clients-wrap', empty: '[data-tautulli-clients-empty]' });
+    drawStackedBar({ id: 'tautulli-clients-stream-type', url: BASE + '/tautulli/api/clients-stream-type?' + qs(), wrap: '#tautulli-clients-wrap', empty: '[data-tautulli-clients-empty]' });
   }
   function refreshSourceRes() {
-    drawStackedBar({ id: 'tautulli-source-res', url: '/tautulli/api/plays-source-res?' + qs(), wrap: '#tautulli-source-res-wrap', empty: '[data-tautulli-source-res-empty]' });
+    drawStackedBar({ id: 'tautulli-source-res', url: BASE + '/tautulli/api/plays-source-res?' + qs(), wrap: '#tautulli-source-res-wrap', empty: '[data-tautulli-source-res-empty]' });
   }
   function refreshStreamRes() {
-    drawStackedBar({ id: 'tautulli-stream-res', url: '/tautulli/api/plays-stream-res?' + qs(), wrap: '#tautulli-stream-res-wrap', empty: '[data-tautulli-stream-res-empty]' });
+    drawStackedBar({ id: 'tautulli-stream-res', url: BASE + '/tautulli/api/plays-stream-res?' + qs(), wrap: '#tautulli-stream-res-wrap', empty: '[data-tautulli-stream-res-empty]' });
   }
   function refreshUsersStream() {
-    drawStackedBar({ id: 'tautulli-users-stream-type', url: '/tautulli/api/users-stream-type?' + qs(), wrap: '#tautulli-users-stream-wrap', empty: '[data-tautulli-users-stream-empty]' });
+    drawStackedBar({ id: 'tautulli-users-stream-type', url: BASE + '/tautulli/api/users-stream-type?' + qs(), wrap: '#tautulli-users-stream-wrap', empty: '[data-tautulli-users-stream-empty]' });
   }
   function refreshConcurrent() {
     // Concurrent is always a count — never reformat as duration.
-    drawStackedBar({ id: 'tautulli-concurrent', url: '/tautulli/api/concurrent?' + qs(), wrap: '#tautulli-concurrent-wrap', empty: '[data-tautulli-concurrent-empty]', metricAware: false });
+    drawStackedBar({ id: 'tautulli-concurrent', url: BASE + '/tautulli/api/concurrent?' + qs(), wrap: '#tautulli-concurrent-wrap', empty: '[data-tautulli-concurrent-empty]', metricAware: false });
   }
   function refreshCharts() {
     refreshPlays(); refreshActivityHour(); refreshActivityDow(); refreshClients();
@@ -366,7 +367,7 @@
   var userSel = frag('[data-tautulli-user]');
   if (userSel) {
     userSel.addEventListener('change', function () { state.userId = userSel.value || ''; refreshAll(); });
-    fetch('/tautulli/api/user-names', { headers: { 'X-Requested-With': 'fetch' }, credentials: 'same-origin' })
+    fetch(BASE + '/tautulli/api/user-names', { headers: { 'X-Requested-With': 'fetch' }, credentials: 'same-origin' })
       .then(function (r) { return r.ok ? r.json() : []; })
       .then(function (list) {
         (list || []).forEach(function (u) {

--- a/symfony/templates/tautulli/index.html.twig
+++ b/symfony/templates/tautulli/index.html.twig
@@ -187,6 +187,7 @@
 <script src="{{ asset('static/chart/chart.umd.min.js') }}"></script>
 <script>
 (function () {
+  var BASE = window.BASE_PATH;
   var HISTORY_PAGE = 25;
   var state = { range: 30, metric: 'plays', userId: '' };
   var playsMode = 'media';
@@ -218,16 +219,16 @@
 
   function refreshNow() {
     if (document.hidden) return;
-    loadFragment('/tautulli/api/now-playing', frag('[data-tautulli-now]'));
+    loadFragment(BASE + '/tautulli/api/now-playing', frag('[data-tautulli-now]'));
   }
   function refreshStats() {
-    loadFragment('/tautulli/api/stats?' + qs(), frag('[data-tautulli-stats]'));
+    loadFragment(BASE + '/tautulli/api/stats?' + qs(), frag('[data-tautulli-stats]'));
   }
   function refreshLibraries() {
-    loadFragment('/tautulli/api/libraries', frag('[data-tautulli-libraries]'));
+    loadFragment(BASE + '/tautulli/api/libraries', frag('[data-tautulli-libraries]'));
   }
   function refreshUsers() {
-    loadFragment('/tautulli/api/users', frag('[data-tautulli-users]')).then(function () {
+    loadFragment(BASE + '/tautulli/api/users', frag('[data-tautulli-users]')).then(function () {
       var box = frag('[data-tautulli-users]');
       if (!box) return;
       box.querySelectorAll('[data-tautulli-secs]').forEach(function (el) {
@@ -238,7 +239,7 @@
 
   function loadHistory(append) {
     if (!append) historyStart = 0;
-    var url = '/tautulli/api/history?length=' + HISTORY_PAGE + '&start=' + historyStart + (state.userId ? '&user=' + encodeURIComponent(state.userId) : '');
+    var url = BASE + '/tautulli/api/history?length=' + HISTORY_PAGE + '&start=' + historyStart + (state.userId ? '&user=' + encodeURIComponent(state.userId) : '');
     fetch(url, { headers: { 'X-Requested-With': 'fetch' }, credentials: 'same-origin' })
       .then(function (r) { return r.ok ? r.text() : ''; })
       .then(function (html) {
@@ -304,29 +305,29 @@
   }
 
   function refreshPlays() {
-    drawStackedBar({ id: 'tautulli-plays', url: '/tautulli/api/plays?' + qs('mode=' + playsMode), wrap: '#tautulli-plays-wrap', empty: '[data-tautulli-plays-empty]' });
+    drawStackedBar({ id: 'tautulli-plays', url: BASE + '/tautulli/api/plays?' + qs('mode=' + playsMode), wrap: '#tautulli-plays-wrap', empty: '[data-tautulli-plays-empty]' });
   }
   function refreshActivityHour() {
-    drawStackedBar({ id: 'tautulli-activity-hour', url: '/tautulli/api/activity-hour?' + qs(), wrap: '#tautulli-activity-hour-wrap', empty: '[data-tautulli-activity-hour-empty]' });
+    drawStackedBar({ id: 'tautulli-activity-hour', url: BASE + '/tautulli/api/activity-hour?' + qs(), wrap: '#tautulli-activity-hour-wrap', empty: '[data-tautulli-activity-hour-empty]' });
   }
   function refreshActivityDow() {
-    drawStackedBar({ id: 'tautulli-activity-dow', url: '/tautulli/api/activity-dow?' + qs(), wrap: '#tautulli-activity-dow-wrap', empty: '[data-tautulli-activity-dow-empty]' });
+    drawStackedBar({ id: 'tautulli-activity-dow', url: BASE + '/tautulli/api/activity-dow?' + qs(), wrap: '#tautulli-activity-dow-wrap', empty: '[data-tautulli-activity-dow-empty]' });
   }
   function refreshClients() {
-    drawStackedBar({ id: 'tautulli-clients-stream-type', url: '/tautulli/api/clients-stream-type?' + qs(), wrap: '#tautulli-clients-wrap', empty: '[data-tautulli-clients-empty]' });
+    drawStackedBar({ id: 'tautulli-clients-stream-type', url: BASE + '/tautulli/api/clients-stream-type?' + qs(), wrap: '#tautulli-clients-wrap', empty: '[data-tautulli-clients-empty]' });
   }
   function refreshSourceRes() {
-    drawStackedBar({ id: 'tautulli-source-res', url: '/tautulli/api/plays-source-res?' + qs(), wrap: '#tautulli-source-res-wrap', empty: '[data-tautulli-source-res-empty]' });
+    drawStackedBar({ id: 'tautulli-source-res', url: BASE + '/tautulli/api/plays-source-res?' + qs(), wrap: '#tautulli-source-res-wrap', empty: '[data-tautulli-source-res-empty]' });
   }
   function refreshStreamRes() {
-    drawStackedBar({ id: 'tautulli-stream-res', url: '/tautulli/api/plays-stream-res?' + qs(), wrap: '#tautulli-stream-res-wrap', empty: '[data-tautulli-stream-res-empty]' });
+    drawStackedBar({ id: 'tautulli-stream-res', url: BASE + '/tautulli/api/plays-stream-res?' + qs(), wrap: '#tautulli-stream-res-wrap', empty: '[data-tautulli-stream-res-empty]' });
   }
   function refreshUsersStream() {
-    drawStackedBar({ id: 'tautulli-users-stream-type', url: '/tautulli/api/users-stream-type?' + qs(), wrap: '#tautulli-users-stream-wrap', empty: '[data-tautulli-users-stream-empty]' });
+    drawStackedBar({ id: 'tautulli-users-stream-type', url: BASE + '/tautulli/api/users-stream-type?' + qs(), wrap: '#tautulli-users-stream-wrap', empty: '[data-tautulli-users-stream-empty]' });
   }
   function refreshConcurrent() {
     // Concurrent is always a count — never reformat as duration.
-    drawStackedBar({ id: 'tautulli-concurrent', url: '/tautulli/api/concurrent?' + qs(), wrap: '#tautulli-concurrent-wrap', empty: '[data-tautulli-concurrent-empty]', metricAware: false });
+    drawStackedBar({ id: 'tautulli-concurrent', url: BASE + '/tautulli/api/concurrent?' + qs(), wrap: '#tautulli-concurrent-wrap', empty: '[data-tautulli-concurrent-empty]', metricAware: false });
   }
   function refreshCharts() {
     refreshPlays(); refreshActivityHour(); refreshActivityDow(); refreshClients();
@@ -366,7 +367,7 @@
   var userSel = frag('[data-tautulli-user]');
   if (userSel) {
     userSel.addEventListener('change', function () { state.userId = userSel.value || ''; refreshAll(); });
-    fetch('/tautulli/api/user-names', { headers: { 'X-Requested-With': 'fetch' }, credentials: 'same-origin' })
+    fetch(BASE + '/tautulli/api/user-names', { headers: { 'X-Requested-With': 'fetch' }, credentials: 'same-origin' })
       .then(function (r) { return r.ok ? r.json() : []; })
       .then(function (list) {
         (list || []).forEach(function (u) {


### PR DESCRIPTION
## Summary

When Prismarr is served behind a reverse proxy that strips a path prefix (e.g. Traefik routing `https://host/prismarr/...` to the container root, with `X-Forwarded-Prefix: /prismarr` forwarded), server-generated URLs are already prefix-safe via `instance_path()` / `path()` (which go through the Symfony router, itself driven by `Request::getBasePath()` — already trusted via `trusted_headers: [..., x-forwarded-prefix]` in `config/packages/framework.yaml`).

However, ~276 places across 67 Twig templates build absolute paths as raw string literals inside inline `<script>` blocks or `href`/action attributes (`fetch('/medias/' + slug + ...)`, `href="/jellyseerr/..."`, etc.). These literals ignore the prefix entirely, since `X-Forwarded-Prefix` only affects server-side URL generation, not raw JS strings.

## Fix

- Standard case (raw text inside a `<script>` block or HTML attribute): prefix the literal with `{{ app.request.getBasePath() }}`.
- Edge case (~9 occurrences already inside an open Twig expression, e.g. `{% include ... with { save_url_edit: ... } %}` or a ternary): use the Twig concat operator `app.request.getBasePath() ~ '...'` instead, since `{{ }}` doesn't interpolate inside an already-parsed Twig expression.
- One occurrence (`/api/health/services`) was switched to the named route via `{{ path('api_health_services') }}` instead, which is cleaner and needed no raw-path handling.

`Request::getBasePath()` already reflects `X-Forwarded-Prefix` (Symfony 5.3+), so this resolves to `/prismarr` behind the proxy and `''` on a root deployment — no extra config needed.

Affected roots: `/medias`, `/decouverte`, `/jellyseerr`, `/prowlarr`, `/setup`.

## Test plan

- [x] `make lint-twig` (`php bin/console lint:twig templates`) — all 149 Twig files pass syntax validation
- [x] Swept the repo for any remaining hardcoded absolute paths on the 5 affected roots — none left
- [x] Manually verified each of the 9 "already inside a Twig expression" cases renders correctly with `~` instead of `{{ }}`