### PR TITLE
fix(qbittorrent): guard against stale pagination responses

### DIFF
--- a/symfony/templates/qbittorrent/index.html.twig
+++ b/symfony/templates/qbittorrent/index.html.twig
@@ -1212,10 +1212,17 @@ body[data-bs-theme="dark"] .qbt-torrent-list[data-view="table"] .qbt-cell-progre
     });
 
     var refreshCtrl = null;
+    var refreshSeq = 0;
     function refreshData() {
         // Annule le fetch précédent s'il est encore en vol (évite empilement)
         if (refreshCtrl) refreshCtrl.abort();
         refreshCtrl = new AbortController();
+        // abort() n'a aucun effet si la réponse précédente est déjà arrivée
+        // (fréquent en local, où le round-trip peut être plus rapide que le
+        // délai clic → exécution JS) : sans ce numéro de séquence, une réponse
+        // de sondage périodique pour l'ancienne page peut s'appliquer APRÈS
+        // celle du clic sur une autre page, et y revenir juste après l'affichage.
+        var seq = ++refreshSeq;
         var q = new URLSearchParams({
             page: pagState.page,
             perPage: pagState.perPage,
@@ -1229,6 +1236,7 @@ body[data-bs-theme="dark"] .qbt-torrent-list[data-view="table"] .qbt-cell-progre
         fetch(BASE + '/api/torrents?' + q, { signal: refreshCtrl.signal, headers: { 'X-Requested-With': 'XMLHttpRequest' } })
         .then(function(r) { return r.json(); })
         .then(function(data) {
+            if (seq !== refreshSeq) return; // une requête plus récente a déjà été émise
             if (data.error) return;
             updateStats(data.stats);
             updateList(data.torrents);


### PR DESCRIPTION
## Summary
- `refreshData()` aborts the previous in-flight fetch before firing a new one, but `abort()` is a no-op once a response has already arrived — common on localhost, where the round-trip can beat the click-to-JS-execution delay.
- A periodic poll response for the old page could land after a user's page-change click and silently snap the view back to the previous page.
- Adds a sequence counter so a response is only applied if no newer request has been issued since, regardless of whether `abort()` actually worked.

## Test plan
- [x] Open the qBittorrent torrents page with several pages of results
- [x] Click to page 2/3 repeatedly right as the periodic auto-refresh would be ticking, confirm the page no longer snaps back to page 1
- [x] `make lint-twig` passes on the changed template

🤖 Generated with [Claude Code](https://claude.com/claude-code)