### PR TITLE
fix: restore the broken star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ enough to keep me going. This release is for you.
 
 ## Star history
 
-[![Star history](https://api.star-history.com/svg?repos=Shoshuo/Prismarr&type=Date)](https://star-history.com/#Shoshuo/Prismarr&Date)
+[![Star history](https://star-history.dera.page/svg?repos=Shoshuo/Prismarr&type=Date)](https://star-history.dera.page/#Shoshuo/Prismarr&Date)
 
 ---
 


### PR DESCRIPTION
The star history chart embedded in the README stopped rendering because the upstream service broke under GitHub's stargazer API restrictions, and its mirror uses the same domain for the API and the frontend. This updates the chart image and its link to a working mirror of the same graph so the readme displays the star history again. The mirror handles requests on the shared domain and needs no API token.