### PR TITLE
Interactive search: link release titles to their tracker page

### DIFF
--- a/symfony/src/Controller/MediaController.php
+++ b/symfony/src/Controller/MediaController.php
@@ -410,6 +410,7 @@ class MediaController extends AbstractController
                 'scoreDetails'      => $scoreDetails,
                 'customFormats'     => array_map(fn($cf) => $cf['name'] ?? '?', $r['customFormats'] ?? []),
                 'languages'         => array_map(fn($l) => $l['name'] ?? '?', $r['languages'] ?? []),
+                'infoUrl'           => $r['infoUrl'] ?? null,
             ];
         }, $raw);
 
@@ -1672,6 +1673,7 @@ class MediaController extends AbstractController
                 'versionLabel'      => $versionLabel,
                 'tvdbLabel'         => $tvdbLabel,
                 'releaseGroup'      => $r['releaseGroup'] ?? '',
+                'infoUrl'           => $r['infoUrl'] ?? null,
             ];
         }, $raw);
 
@@ -1817,6 +1819,7 @@ class MediaController extends AbstractController
                 'episodeRequested'  => (bool) ($r['episodeRequested'] ?? true),
                 'versionLabel'      => $versionLabel,
                 'releaseGroup'      => $r['releaseGroup'] ?? '',
+                'infoUrl'           => $r['infoUrl'] ?? null,
             ];
         }, $raw);
 

--- a/symfony/src/Controller/MediaController.php
+++ b/symfony/src/Controller/MediaController.php
@@ -69,6 +69,20 @@ class MediaController extends AbstractController
     }
 
     /**
+     * Only http(s) URLs are safe to emit as release tracker links.
+     * `infoUrl` is passed through verbatim from the Radarr/Sonarr release
+     * payload (in turn sourced from whatever indexer answered the search),
+     * so a compromised/hostile indexer could return a `javascript:`/`data:`
+     * URL — reject anything that isn't http(s) before it ever reaches the
+     * frontend, rather than relying on the page's CSP (this becomes an
+     * upstream PR where that CSP does not exist).
+     */
+    private static function safeInfoUrl(mixed $url): ?string
+    {
+        return (is_string($url) && preg_match('~^https?://~i', $url) === 1) ? $url : null;
+    }
+
+    /**
      * v1.1.0 Phase C — slug is mandatory, injected via the class-level
      * /medias/{slug} prefix. The autowired RadarrClient is already bound
      * to the right instance by MultiInstanceBinderSubscriber before this
@@ -410,7 +424,7 @@ class MediaController extends AbstractController
                 'scoreDetails'      => $scoreDetails,
                 'customFormats'     => array_map(fn($cf) => $cf['name'] ?? '?', $r['customFormats'] ?? []),
                 'languages'         => array_map(fn($l) => $l['name'] ?? '?', $r['languages'] ?? []),
-                'infoUrl'           => $r['infoUrl'] ?? null,
+                'infoUrl'           => self::safeInfoUrl($r['infoUrl'] ?? null),
             ];
         }, $raw);
 
@@ -1673,7 +1687,7 @@ class MediaController extends AbstractController
                 'versionLabel'      => $versionLabel,
                 'tvdbLabel'         => $tvdbLabel,
                 'releaseGroup'      => $r['releaseGroup'] ?? '',
-                'infoUrl'           => $r['infoUrl'] ?? null,
+                'infoUrl'           => self::safeInfoUrl($r['infoUrl'] ?? null),
             ];
         }, $raw);
 
@@ -1819,7 +1833,7 @@ class MediaController extends AbstractController
                 'episodeRequested'  => (bool) ($r['episodeRequested'] ?? true),
                 'versionLabel'      => $versionLabel,
                 'releaseGroup'      => $r['releaseGroup'] ?? '',
-                'infoUrl'           => $r['infoUrl'] ?? null,
+                'infoUrl'           => self::safeInfoUrl($r['infoUrl'] ?? null),
             ];
         }, $raw);
 

--- a/symfony/templates/media/films.html.twig
+++ b/symfony/templates/media/films.html.twig
@@ -2350,10 +2350,14 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
       }).join('');
       var langBadges = (r.languages || []).map(function(l) { return '<span class="badge bg-cyan-lt" style="font-size:.65rem">' + esc(l) + '</span>'; }).join(' ');
 
+      var titleHtml = r.infoUrl
+        ? '<a href="' + esc(r.infoUrl) + '" target="_blank" rel="noopener" class="text-reset">' + esc(r.title) + '</a>'
+        : esc(r.title);
+
       tr.innerHTML =
         '<td class="text-truncate" style="max-width:200px" title="' + esc(r.title) + '">' +
           (approved ? '' : '<span class="text-danger me-1" title="' + esc(rejTip) + '">&#10007;</span>') +
-          esc(r.title) +
+          titleHtml +
         '</td>' +
         '<td class="text-nowrap text-muted small">' + esc(r.indexer) + '</td>' +
         '<td class="text-nowrap"><span class="badge bg-blue-lt">' + esc(r.quality) + '</span></td>' +

--- a/symfony/templates/media/series.html.twig
+++ b/symfony/templates/media/series.html.twig
@@ -3632,10 +3632,14 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
       else if (r.fullSeason && r.episodeRequested) sceneColor = '#f59e0b';
       else sceneColor = '#6b7280';
 
+      var titleHtml = r.infoUrl
+        ? '<a href="' + esc(r.infoUrl) + '" target="_blank" rel="noopener" class="text-reset">' + esc(r.title) + '</a>'
+        : esc(r.title);
+
       tr.innerHTML =
         '<td class="text-truncate" style="max-width:200px" title="' + esc(r.title) + '">' +
           (approved ? '' : '<span class="text-danger me-1" title="' + esc(rejTip) + '">&#10007;</span>') +
-          esc(r.title) +
+          titleHtml +
         '</td>' +
         '<td class="text-nowrap text-muted small">' + esc(r.indexer) + '</td>' +
         '<td class="text-nowrap"><span class="badge bg-blue-lt">' + esc(r.quality) + '</span></td>' +

--- a/symfony/tests/Controller/MediaReleasesSearchTest.php
+++ b/symfony/tests/Controller/MediaReleasesSearchTest.php
@@ -91,4 +91,52 @@ class MediaReleasesSearchTest extends TestCase
         $this->assertSame(200, $res->getStatusCode());
         $this->assertSame('[]', $res->getContent());
     }
+
+    public function testFilmReleasesMapsInfoUrlFromRadarrPayload(): void
+    {
+        $radarr = $this->createMock(RadarrClient::class);
+        $radarr->method('getMovie')->willReturn(null);
+        $radarr->method('getReleasesForMovie')->willReturn([
+            ['guid' => 'a', 'indexerId' => 1, 'title' => 'Release A', 'infoUrl' => 'https://tracker.example/torrent/1'],
+            ['guid' => 'b', 'indexerId' => 2, 'title' => 'Release B'],
+        ]);
+
+        $res = $this->controller(radarr: $radarr)->filmReleases(1);
+        $this->assertSame(200, $res->getStatusCode());
+        $rows = json_decode($res->getContent(), true);
+        $this->assertSame('https://tracker.example/torrent/1', $rows[0]['infoUrl']);
+        $this->assertNull($rows[1]['infoUrl']);
+    }
+
+    public function testEpisodeReleasesMapsInfoUrlFromSonarrPayload(): void
+    {
+        $sonarr = $this->createMock(SonarrClient::class);
+        $sonarr->method('getEpisode')->willReturn(null);
+        $sonarr->method('getEpisodeReleases')->willReturn([
+            ['guid' => 'a', 'indexerId' => 1, 'title' => 'Release A', 'infoUrl' => 'https://tracker.example/torrent/1'],
+            ['guid' => 'b', 'indexerId' => 2, 'title' => 'Release B'],
+        ]);
+
+        $res = $this->controller(sonarr: $sonarr)->episodeReleases(1);
+        $this->assertSame(200, $res->getStatusCode());
+        $rows = json_decode($res->getContent(), true);
+        $this->assertSame('https://tracker.example/torrent/1', $rows[0]['infoUrl']);
+        $this->assertNull($rows[1]['infoUrl']);
+    }
+
+    public function testSeasonReleasesMapsInfoUrlFromSonarrPayload(): void
+    {
+        $sonarr = $this->createMock(SonarrClient::class);
+        $sonarr->method('getSerie')->willReturn(null);
+        $sonarr->method('getSeasonReleases')->willReturn([
+            ['guid' => 'a', 'indexerId' => 1, 'title' => 'Release A', 'infoUrl' => 'https://tracker.example/torrent/1'],
+            ['guid' => 'b', 'indexerId' => 2, 'title' => 'Release B'],
+        ]);
+
+        $res = $this->controller(sonarr: $sonarr)->seasonReleases(1, 1);
+        $this->assertSame(200, $res->getStatusCode());
+        $rows = json_decode($res->getContent(), true);
+        $this->assertSame('https://tracker.example/torrent/1', $rows[0]['infoUrl']);
+        $this->assertNull($rows[1]['infoUrl']);
+    }
 }

--- a/symfony/tests/Controller/MediaReleasesSearchTest.php
+++ b/symfony/tests/Controller/MediaReleasesSearchTest.php
@@ -92,51 +92,63 @@ class MediaReleasesSearchTest extends TestCase
         $this->assertSame('[]', $res->getContent());
     }
 
+    /**
+     * @return array<int, array<string, mixed>> five rows exercising every
+     *   `safeInfoUrl()` branch: a plain https URL (kept), a missing key
+     *   (null), a `javascript:` URL (rejected — XSS vector), an uppercase
+     *   `HTTPS://` scheme (kept — case-insensitive), and a non-string value
+     *   (rejected).
+     */
+    private function infoUrlFixtureRows(): array
+    {
+        return [
+            ['guid' => 'a', 'indexerId' => 1, 'title' => 'Release A', 'infoUrl' => 'https://tracker.example/torrent/1'],
+            ['guid' => 'b', 'indexerId' => 2, 'title' => 'Release B'],
+            ['guid' => 'c', 'indexerId' => 3, 'title' => 'Release C', 'infoUrl' => 'javascript:alert(1)'],
+            ['guid' => 'd', 'indexerId' => 4, 'title' => 'Release D', 'infoUrl' => 'HTTPS://tracker.example/x'],
+            ['guid' => 'e', 'indexerId' => 5, 'title' => 'Release E', 'infoUrl' => 42],
+        ];
+    }
+
+    private function assertInfoUrlFixtureRowsMappedSafely(array $rows): void
+    {
+        $this->assertSame('https://tracker.example/torrent/1', $rows[0]['infoUrl']);
+        $this->assertNull($rows[1]['infoUrl']);
+        $this->assertNull($rows[2]['infoUrl'], 'javascript: URL must not reach the frontend as infoUrl');
+        $this->assertSame('HTTPS://tracker.example/x', $rows[3]['infoUrl'], 'uppercase scheme must still be accepted');
+        $this->assertNull($rows[4]['infoUrl'], 'non-string infoUrl must map to null');
+    }
+
     public function testFilmReleasesMapsInfoUrlFromRadarrPayload(): void
     {
         $radarr = $this->createMock(RadarrClient::class);
         $radarr->method('getMovie')->willReturn(null);
-        $radarr->method('getReleasesForMovie')->willReturn([
-            ['guid' => 'a', 'indexerId' => 1, 'title' => 'Release A', 'infoUrl' => 'https://tracker.example/torrent/1'],
-            ['guid' => 'b', 'indexerId' => 2, 'title' => 'Release B'],
-        ]);
+        $radarr->method('getReleasesForMovie')->willReturn($this->infoUrlFixtureRows());
 
         $res = $this->controller(radarr: $radarr)->filmReleases(1);
         $this->assertSame(200, $res->getStatusCode());
-        $rows = json_decode($res->getContent(), true);
-        $this->assertSame('https://tracker.example/torrent/1', $rows[0]['infoUrl']);
-        $this->assertNull($rows[1]['infoUrl']);
+        $this->assertInfoUrlFixtureRowsMappedSafely(json_decode($res->getContent(), true));
     }
 
     public function testEpisodeReleasesMapsInfoUrlFromSonarrPayload(): void
     {
         $sonarr = $this->createMock(SonarrClient::class);
         $sonarr->method('getEpisode')->willReturn(null);
-        $sonarr->method('getEpisodeReleases')->willReturn([
-            ['guid' => 'a', 'indexerId' => 1, 'title' => 'Release A', 'infoUrl' => 'https://tracker.example/torrent/1'],
-            ['guid' => 'b', 'indexerId' => 2, 'title' => 'Release B'],
-        ]);
+        $sonarr->method('getEpisodeReleases')->willReturn($this->infoUrlFixtureRows());
 
         $res = $this->controller(sonarr: $sonarr)->episodeReleases(1);
         $this->assertSame(200, $res->getStatusCode());
-        $rows = json_decode($res->getContent(), true);
-        $this->assertSame('https://tracker.example/torrent/1', $rows[0]['infoUrl']);
-        $this->assertNull($rows[1]['infoUrl']);
+        $this->assertInfoUrlFixtureRowsMappedSafely(json_decode($res->getContent(), true));
     }
 
     public function testSeasonReleasesMapsInfoUrlFromSonarrPayload(): void
     {
         $sonarr = $this->createMock(SonarrClient::class);
         $sonarr->method('getSerie')->willReturn(null);
-        $sonarr->method('getSeasonReleases')->willReturn([
-            ['guid' => 'a', 'indexerId' => 1, 'title' => 'Release A', 'infoUrl' => 'https://tracker.example/torrent/1'],
-            ['guid' => 'b', 'indexerId' => 2, 'title' => 'Release B'],
-        ]);
+        $sonarr->method('getSeasonReleases')->willReturn($this->infoUrlFixtureRows());
 
         $res = $this->controller(sonarr: $sonarr)->seasonReleases(1, 1);
         $this->assertSame(200, $res->getStatusCode());
-        $rows = json_decode($res->getContent(), true);
-        $this->assertSame('https://tracker.example/torrent/1', $rows[0]['infoUrl']);
-        $this->assertNull($rows[1]['infoUrl']);
+        $this->assertInfoUrlFixtureRowsMappedSafely(json_decode($res->getContent(), true));
     }
 }


### PR DESCRIPTION
Fixes #35.

Radarr/Sonarr already return an `infoUrl` per release; the release mappers just dropped it. This PR:

- maps `infoUrl` in all three interactive-search endpoints (film / episode / season) through a small `safeInfoUrl()` allowlist — only `http(s)://` URLs are emitted, anything else (including `javascript:`/`data:` from a hostile indexer) maps to `null`;
- wraps the release title in `<a href target="_blank" rel="noopener">` in both release tables when an `infoUrl` is present, plain text otherwise. The rejection marker stays outside the link.

Tests: `MediaReleasesSearchTest` gains mapping tests for all three endpoints (URL kept, missing key → null, `javascript:` → null, uppercase `HTTPS://` kept, non-string → null). 7 tests / 24 assertions green, `lint:twig` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)