### PR TITLE
SABnzbd/NZBGet: show recent history inline on the downloads page

### DIFF
--- a/symfony/src/Controller/UsenetController.php
+++ b/symfony/src/Controller/UsenetController.php
@@ -31,6 +31,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[Route('/usenet/{client}', name: 'app_usenet_', requirements: ['client' => 'sabnzbd|nzbget'])]
 class UsenetController extends AbstractController
 {
+    /** Rows in the downloads page's "Recent history" preview (#47). */
+    private const RECENT_HISTORY_LIMIT = 15;
+
     public function __construct(
         private readonly SabnzbdClient $sabnzbd,
         private readonly NzbgetClient $nzbget,
@@ -96,13 +99,35 @@ class UsenetController extends AbstractController
         } catch (\Throwable) {
         }
 
+        // Recent history preview (#47): server-rendered once, at page load —
+        // the queue keeps its JS poller, history doesn't need one. Skipped when
+        // the probe already failed: the page shows its unreachable banner
+        // instead, and a doomed call would just burn the connect timeout.
+        $recentHistory = [];
+        $historyTotal  = 0;
+        if ($reason === null) {
+            try {
+                $hist = $this->client($client)->getHistoryPage(0, self::RECENT_HISTORY_LIMIT);
+                $recentHistory = $hist['items'];
+                $historyTotal  = $hist['total'];
+            } catch (\Throwable $e) {
+                $this->logger->warning('Usenet recent history failed', [
+                    'client'    => $client,
+                    'exception' => $e::class,
+                    'message'   => $e->getMessage(),
+                ]);
+            }
+        }
+
         return $this->render('usenet/index.html.twig', [
-            'client'       => $client,
-            'client_label' => $label,
-            'error'        => $reason !== null,
-            'error_reason' => $reason ?? 'unreachable',
-            'service_url'  => $this->config->get($client . '_url'),
-            'categories'   => $categories,
+            'client'         => $client,
+            'client_label'   => $label,
+            'error'          => $reason !== null,
+            'error_reason'   => $reason ?? 'unreachable',
+            'service_url'    => $this->config->get($client . '_url'),
+            'categories'     => $categories,
+            'recent_history' => $recentHistory,
+            'history_total'  => $historyTotal,
         ]);
     }
 

--- a/symfony/src/Controller/UsenetController.php
+++ b/symfony/src/Controller/UsenetController.php
@@ -14,6 +14,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -34,6 +36,23 @@ class UsenetController extends AbstractController
     /** Rows in the downloads page's "Recent history" preview (#47). */
     private const RECENT_HISTORY_LIMIT = 15;
 
+    /**
+     * Cache window for that preview. NZBGet's history RPC has no upstream
+     * paging — getHistoryPage() pulls the whole retained history and slices
+     * locally — so an uncached preview would drag that payload across the wire
+     * on every page render. History only grows when a job finishes, so a short
+     * window needs no invalidation.
+     *
+     * @internal Exposed for tests; matches MediaLibraryCache::TTL.
+     */
+    public const RECENT_HISTORY_TTL = 45; // seconds
+
+    /** @internal Exposed for tests — one key per client, never shared. */
+    public static function recentHistoryCacheKey(string $client): string
+    {
+        return 'usenet.recent_history.' . $client;
+    }
+
     public function __construct(
         private readonly SabnzbdClient $sabnzbd,
         private readonly NzbgetClient $nzbget,
@@ -41,6 +60,7 @@ class UsenetController extends AbstractController
         private readonly ConfigService $config,
         private readonly LoggerInterface $logger,
         private readonly TranslatorInterface $translator,
+        private readonly CacheInterface $cache,
     ) {}
 
     private function client(string $kind): UsenetClientInterface
@@ -103,11 +123,25 @@ class UsenetController extends AbstractController
         // the queue keeps its JS poller, history doesn't need one. Skipped when
         // the probe already failed: the page shows its unreachable banner
         // instead, and a doomed call would just burn the connect timeout.
+        //
+        // Behind a short per-client cache: NZBGet's history RPC returns the
+        // WHOLE retained history (the client slices locally), so an uncached
+        // preview would pull an unbounded payload on every render. An empty
+        // result isn't cached, and a throwing fetch caches nothing at all, so
+        // neither a fresh install nor a transient failure gets pinned for the
+        // window.
         $recentHistory = [];
         $historyTotal  = 0;
         if ($reason === null) {
             try {
-                $hist = $this->client($client)->getHistoryPage(0, self::RECENT_HISTORY_LIMIT);
+                $hist = $this->cache->get(
+                    self::recentHistoryCacheKey($client),
+                    function (ItemInterface $item) use ($client): array {
+                        $result = $this->client($client)->getHistoryPage(0, self::RECENT_HISTORY_LIMIT);
+                        $item->expiresAfter($result['items'] === [] ? 0 : self::RECENT_HISTORY_TTL);
+                        return $result;
+                    },
+                );
                 $recentHistory = $hist['items'];
                 $historyTotal  = $hist['total'];
             } catch (\Throwable $e) {

--- a/symfony/src/Service/Media/Usenet/NzbgetClient.php
+++ b/symfony/src/Service/Media/Usenet/NzbgetClient.php
@@ -285,6 +285,10 @@ class NzbgetClient implements UsenetClientInterface
             speedBytes:     0,
             failMessage:    $status === UsenetStatus::FAILED && $raw !== '' ? $raw : null,
             isHistory:      true,
+            // NZBGet's history entries carry HistoryTime — the unix epoch the
+            // job landed in history, i.e. when it finished. Absent on some entry
+            // kinds (DUP/URL stubs), so 0 / missing stays null.
+            completedAt:    ((int) ($h['HistoryTime'] ?? 0)) ?: null,
         );
     }
 

--- a/symfony/src/Service/Media/Usenet/SabnzbdClient.php
+++ b/symfony/src/Service/Media/Usenet/SabnzbdClient.php
@@ -280,6 +280,10 @@ class SabnzbdClient implements UsenetClientInterface
             speedBytes:     0,
             failMessage:    $fail !== '' ? $fail : null,
             isHistory:      true,
+            // SABnzbd stamps the finish time as a unix epoch in `completed`;
+            // 0 / absent means "unknown", which must stay null so the UI never
+            // renders a 1970 date.
+            completedAt:    ((int) ($s['completed'] ?? 0)) ?: null,
         );
     }
 

--- a/symfony/src/Service/Media/Usenet/UsenetDownload.php
+++ b/symfony/src/Service/Media/Usenet/UsenetDownload.php
@@ -32,5 +32,10 @@ final readonly class UsenetDownload
         public bool $isHistory,
         /** Retry countdown (seconds) while FETCHING an NZB from a URL, else null. */
         public ?int $waitSeconds = null,
+        /**
+         * Unix epoch the job finished, for history entries only — null when the
+         * downloader doesn't report one (and always null for queue slots).
+         */
+        public ?int $completedAt = null,
     ) {}
 }

--- a/symfony/templates/usenet/_history_rows.html.twig
+++ b/symfony/templates/usenet/_history_rows.html.twig
@@ -4,33 +4,9 @@
    Context: `items` (UsenetDownload[], history entries) and `client`
    (sabnzbd|nzbget — only used to translate NZBGet's raw failure codes).
 
-   The .uh-* CSS lives here rather than in a page stylesheets block so both
-   pages get it from the single include (style-src allows inline styles). #}
+   Markup only: the .uh-* CSS lives in _history_styles.html.twig, which both
+   including pages pull into their {% block stylesheets %}. #}
 {% import '_icons.html.twig' as ico %}
-<style>
-.uh-list { display:flex; flex-direction:column; gap:.3rem; }
-.uh-row {
-    display:grid; grid-template-columns:30px 1fr auto; gap:.7rem; align-items:center;
-    padding:.5rem .8rem; background:var(--tblr-bg-surface);
-    border:1px solid var(--tblr-border-color); border-left:3px solid var(--tblr-border-color); border-radius:6px;
-}
-.uh-row[data-status="completed"] { border-left-color:#22c55e; }
-.uh-row[data-status="failed"]    { border-left-color:#ef4444; }
-.uh-ico { width:30px; height:30px; display:flex; align-items:center; justify-content:center; border-radius:7px; background:var(--tblr-bg-surface-secondary); color:var(--tblr-text-secondary); }
-.uh-ico svg { width:15px; height:15px; }
-.uh-row[data-status="completed"] .uh-ico { color:#22c55e; }
-.uh-row[data-status="failed"] .uh-ico { color:#ef4444; }
-.uh-name { font-size:.8rem; font-weight:600; color:var(--tblr-body-color); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
-.uh-meta { font-size:.7rem; color:var(--tblr-text-secondary); margin-top:2px; }
-.uh-fail { color:#ef4444; }
-.uh-tag { display:inline-block; font-size:.6rem; padding:1px 6px; border-radius:3px; font-weight:600; text-transform:uppercase; letter-spacing:.3px; background:rgba(var(--tblr-primary-rgb),.14); color:var(--tblr-primary); margin-left:.4rem; }
-.uh-side { text-align:right; font-size:.72rem; color:var(--tblr-text-secondary); white-space:nowrap; }
-.uh-pill { display:inline-block; font-size:.6rem; font-weight:700; padding:1px 7px; border-radius:3px; text-transform:uppercase; letter-spacing:.3px; background:var(--tblr-bg-surface-secondary); }
-.uh-row[data-status="completed"] .uh-pill { background:rgba(34,197,94,.15); color:#16a34a; }
-.uh-row[data-status="failed"] .uh-pill { background:rgba(239,68,68,.15); color:#dc2626; }
-/* .7rem = 11.2px — stays above PRODUCT.md's 11px mobile readability floor. */
-.uh-age { font-size:.7rem; color:var(--tblr-text-secondary); margin-top:2px; }
-</style>
 {% for item in items %}
   {% set fail = item.failMessage %}
   {% if fail and client == 'nzbget' %}

--- a/symfony/templates/usenet/_history_rows.html.twig
+++ b/symfony/templates/usenet/_history_rows.html.twig
@@ -1,0 +1,58 @@
+{# Usenet history rows — shared by the paginated history page and the "Recent
+   history" preview on the downloads page (#47).
+
+   Context: `items` (UsenetDownload[], history entries) and `client`
+   (sabnzbd|nzbget — only used to translate NZBGet's raw failure codes).
+
+   The .uh-* CSS lives here rather than in a page stylesheets block so both
+   pages get it from the single include (style-src allows inline styles). #}
+{% import '_icons.html.twig' as ico %}
+<style>
+.uh-list { display:flex; flex-direction:column; gap:.3rem; }
+.uh-row {
+    display:grid; grid-template-columns:30px 1fr auto; gap:.7rem; align-items:center;
+    padding:.5rem .8rem; background:var(--tblr-bg-surface);
+    border:1px solid var(--tblr-border-color); border-left:3px solid var(--tblr-border-color); border-radius:6px;
+}
+.uh-row[data-status="completed"] { border-left-color:#22c55e; }
+.uh-row[data-status="failed"]    { border-left-color:#ef4444; }
+.uh-ico { width:30px; height:30px; display:flex; align-items:center; justify-content:center; border-radius:7px; background:var(--tblr-bg-surface-secondary); color:var(--tblr-text-secondary); }
+.uh-ico svg { width:15px; height:15px; }
+.uh-row[data-status="completed"] .uh-ico { color:#22c55e; }
+.uh-row[data-status="failed"] .uh-ico { color:#ef4444; }
+.uh-name { font-size:.8rem; font-weight:600; color:var(--tblr-body-color); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.uh-meta { font-size:.7rem; color:var(--tblr-text-secondary); margin-top:2px; }
+.uh-fail { color:#ef4444; }
+.uh-tag { display:inline-block; font-size:.6rem; padding:1px 6px; border-radius:3px; font-weight:600; text-transform:uppercase; letter-spacing:.3px; background:rgba(var(--tblr-primary-rgb),.14); color:var(--tblr-primary); margin-left:.4rem; }
+.uh-side { text-align:right; font-size:.72rem; color:var(--tblr-text-secondary); white-space:nowrap; }
+.uh-pill { display:inline-block; font-size:.6rem; font-weight:700; padding:1px 7px; border-radius:3px; text-transform:uppercase; letter-spacing:.3px; background:var(--tblr-bg-surface-secondary); }
+.uh-row[data-status="completed"] .uh-pill { background:rgba(34,197,94,.15); color:#16a34a; }
+.uh-row[data-status="failed"] .uh-pill { background:rgba(239,68,68,.15); color:#dc2626; }
+/* .7rem = 11.2px — stays above PRODUCT.md's 11px mobile readability floor. */
+.uh-age { font-size:.7rem; color:var(--tblr-text-secondary); margin-top:2px; }
+</style>
+{% for item in items %}
+  {% set fail = item.failMessage %}
+  {% if fail and client == 'nzbget' %}
+    {% set _k = 'usenet.nzbget_fail.' ~ (item.rawStatus|split('/')|last|lower) %}
+    {% set _t = _k|trans %}
+    {% set fail = _t != _k ? _t : fail %}
+  {% endif %}
+  <div class="uh-row" data-status="{{ item.status }}">
+    <div class="uh-ico">
+      {% if item.status == 'failed' %}{{ ico.icon('alert-triangle', '', 15) }}
+      {% elseif item.status == 'completed' %}{{ ico.icon('check', '', 15) }}
+      {% else %}{{ ico.icon('clock', '', 15) }}{% endif %}
+    </div>
+    <div style="min-width:0;">
+      <div class="uh-name" title="{{ item.name }}">{{ item.name }}{% if item.category %}<span class="uh-tag">{{ item.category }}</span>{% endif %}</div>
+      <div class="uh-meta">{{ item.sizeBytes|prismarr_bytes }}{% if fail %} · <span class="uh-fail">{{ fail }}</span>{% endif %}</div>
+    </div>
+    <div class="uh-side">
+      <span class="uh-pill">{{ ('usenet.status.' ~ item.status)|trans }}</span>
+      {# Downloaders don't always stamp a finish time (older SABnzbd, NZBGet
+         URL/DUP stubs) — keep the column aligned with an em dash. #}
+      <div class="uh-age">{{ item.completedAt ? item.completedAt|relative_date : '—' }}</div>
+    </div>
+  </div>
+{% endfor %}

--- a/symfony/templates/usenet/_history_styles.html.twig
+++ b/symfony/templates/usenet/_history_styles.html.twig
@@ -1,0 +1,29 @@
+{# Styling for the shared usenet history rows (_history_rows.html.twig).
+   Included from the {% block stylesheets %} of BOTH pages that render those
+   rows — the paginated history page and the downloads page's "Recent history"
+   preview — so the rules have a single home and neither page duplicates them.
+   Same idiom as dashboard/_plex_styles.html.twig. #}
+<style>
+.uh-list { display:flex; flex-direction:column; gap:.3rem; }
+.uh-row {
+    display:grid; grid-template-columns:30px 1fr auto; gap:.7rem; align-items:center;
+    padding:.5rem .8rem; background:var(--tblr-bg-surface);
+    border:1px solid var(--tblr-border-color); border-left:3px solid var(--tblr-border-color); border-radius:6px;
+}
+.uh-row[data-status="completed"] { border-left-color:#22c55e; }
+.uh-row[data-status="failed"]    { border-left-color:#ef4444; }
+.uh-ico { width:30px; height:30px; display:flex; align-items:center; justify-content:center; border-radius:7px; background:var(--tblr-bg-surface-secondary); color:var(--tblr-text-secondary); }
+.uh-ico svg { width:15px; height:15px; }
+.uh-row[data-status="completed"] .uh-ico { color:#22c55e; }
+.uh-row[data-status="failed"] .uh-ico { color:#ef4444; }
+.uh-name { font-size:.8rem; font-weight:600; color:var(--tblr-body-color); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.uh-meta { font-size:.7rem; color:var(--tblr-text-secondary); margin-top:2px; }
+.uh-fail { color:#ef4444; }
+.uh-tag { display:inline-block; font-size:.6rem; padding:1px 6px; border-radius:3px; font-weight:600; text-transform:uppercase; letter-spacing:.3px; background:rgba(var(--tblr-primary-rgb),.14); color:var(--tblr-primary); margin-left:.4rem; }
+.uh-side { text-align:right; font-size:.72rem; color:var(--tblr-text-secondary); white-space:nowrap; }
+.uh-pill { display:inline-block; font-size:.6rem; font-weight:700; padding:1px 7px; border-radius:3px; text-transform:uppercase; letter-spacing:.3px; background:var(--tblr-bg-surface-secondary); }
+.uh-row[data-status="completed"] .uh-pill { background:rgba(34,197,94,.15); color:#16a34a; }
+.uh-row[data-status="failed"] .uh-pill { background:rgba(239,68,68,.15); color:#dc2626; }
+/* .7rem = 11.2px — stays above PRODUCT.md's 11px mobile readability floor. */
+.uh-age { font-size:.7rem; color:var(--tblr-text-secondary); margin-top:2px; }
+</style>

--- a/symfony/templates/usenet/history.html.twig
+++ b/symfony/templates/usenet/history.html.twig
@@ -3,6 +3,10 @@
 {% block title %}{{ 'usenet.history.title'|trans }} — {{ client_label }}{% endblock %}
 {% block page_title %}<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="{{ client == 'nzbget' ? '#1f9c3a' : '#ffa000' }}" stroke-width="2"><path d="M12 8v4l3 3"/><path d="M3.05 11a9 9 0 1 1 .5 4"/><path d="M3 4v5h5"/></svg> {{ client_label }} — {{ 'usenet.history.title'|trans }}{% endblock %}
 
+{% block stylesheets %}
+{% include 'usenet/_history_styles.html.twig' %}
+{% endblock %}
+
 {% block body %}
 <div class="d-flex align-items-center mb-3">
   <a href="{{ path('app_usenet_index', {client: client}) }}" class="btn btn-sm btn-outline-secondary">

--- a/symfony/templates/usenet/history.html.twig
+++ b/symfony/templates/usenet/history.html.twig
@@ -3,31 +3,6 @@
 {% block title %}{{ 'usenet.history.title'|trans }} — {{ client_label }}{% endblock %}
 {% block page_title %}<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="{{ client == 'nzbget' ? '#1f9c3a' : '#ffa000' }}" stroke-width="2"><path d="M12 8v4l3 3"/><path d="M3.05 11a9 9 0 1 1 .5 4"/><path d="M3 4v5h5"/></svg> {{ client_label }} — {{ 'usenet.history.title'|trans }}{% endblock %}
 
-{% block stylesheets %}
-<style>
-.uh-list { display:flex; flex-direction:column; gap:.3rem; }
-.uh-row {
-    display:grid; grid-template-columns:30px 1fr auto; gap:.7rem; align-items:center;
-    padding:.5rem .8rem; background:var(--tblr-bg-surface);
-    border:1px solid var(--tblr-border-color); border-left:3px solid var(--tblr-border-color); border-radius:6px;
-}
-.uh-row[data-status="completed"] { border-left-color:#22c55e; }
-.uh-row[data-status="failed"]    { border-left-color:#ef4444; }
-.uh-ico { width:30px; height:30px; display:flex; align-items:center; justify-content:center; border-radius:7px; background:var(--tblr-bg-surface-secondary); color:var(--tblr-text-secondary); }
-.uh-ico svg { width:15px; height:15px; }
-.uh-row[data-status="completed"] .uh-ico { color:#22c55e; }
-.uh-row[data-status="failed"] .uh-ico { color:#ef4444; }
-.uh-name { font-size:.8rem; font-weight:600; color:var(--tblr-body-color); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
-.uh-meta { font-size:.7rem; color:var(--tblr-text-secondary); margin-top:2px; }
-.uh-fail { color:#ef4444; }
-.uh-tag { display:inline-block; font-size:.6rem; padding:1px 6px; border-radius:3px; font-weight:600; text-transform:uppercase; letter-spacing:.3px; background:rgba(var(--tblr-primary-rgb),.14); color:var(--tblr-primary); margin-left:.4rem; }
-.uh-side { text-align:right; font-size:.72rem; color:var(--tblr-text-secondary); white-space:nowrap; }
-.uh-pill { display:inline-block; font-size:.6rem; font-weight:700; padding:1px 7px; border-radius:3px; text-transform:uppercase; letter-spacing:.3px; background:var(--tblr-bg-surface-secondary); }
-.uh-row[data-status="completed"] .uh-pill { background:rgba(34,197,94,.15); color:#16a34a; }
-.uh-row[data-status="failed"] .uh-pill { background:rgba(239,68,68,.15); color:#dc2626; }
-</style>
-{% endblock %}
-
 {% block body %}
 <div class="d-flex align-items-center mb-3">
   <a href="{{ path('app_usenet_index', {client: client}) }}" class="btn btn-sm btn-outline-secondary">
@@ -42,26 +17,7 @@
   <div class="card"><div class="card-body text-center text-muted py-5">{{ 'usenet.history.empty'|trans }}</div></div>
 {% else %}
   <div class="uh-list">
-    {% for item in items %}
-      {% set fail = item.failMessage %}
-      {% if fail and client == 'nzbget' %}
-        {% set _k = 'usenet.nzbget_fail.' ~ (item.rawStatus|split('/')|last|lower) %}
-        {% set _t = _k|trans %}
-        {% set fail = _t != _k ? _t : fail %}
-      {% endif %}
-      <div class="uh-row" data-status="{{ item.status }}">
-        <div class="uh-ico">
-          {% if item.status == 'failed' %}{{ ico.icon('alert-triangle', '', 15) }}
-          {% elseif item.status == 'completed' %}{{ ico.icon('check', '', 15) }}
-          {% else %}{{ ico.icon('clock', '', 15) }}{% endif %}
-        </div>
-        <div style="min-width:0;">
-          <div class="uh-name" title="{{ item.name }}">{{ item.name }}{% if item.category %}<span class="uh-tag">{{ item.category }}</span>{% endif %}</div>
-          <div class="uh-meta">{{ item.sizeBytes|prismarr_bytes }}{% if fail %} · <span class="uh-fail">{{ fail }}</span>{% endif %}</div>
-        </div>
-        <div class="uh-side"><span class="uh-pill">{{ ('usenet.status.' ~ item.status)|trans }}</span></div>
-      </div>
-    {% endfor %}
+    {% include 'usenet/_history_rows.html.twig' with {items: items, client: client} only %}
   </div>
 
   {% if total_pages > 1 %}

--- a/symfony/templates/usenet/index.html.twig
+++ b/symfony/templates/usenet/index.html.twig
@@ -304,6 +304,28 @@ body[data-bs-theme="dark"] .usenet-view-switcher { background:rgba(255,255,255,.
   <div class="usenet-list" data-usenet-queue data-view="list"></div>
   <div class="usenet-empty text-muted small text-center py-3" data-usenet-queue-empty hidden>{{ 'usenet.empty'|trans }}</div>
 
+  {# ─── Recent history (#47) ────────────────────────────────────── #}
+  {# Server-rendered at page load (no poller): what just finished is the
+     question the queue can't answer once a job leaves it. #}
+  {% if recent_history is not empty %}
+  <div class="card mt-3">
+    <div class="card-header py-2">
+      <h3 class="card-title" style="font-size:.82rem;">{{ 'usenet.history.recent_title'|trans }}</h3>
+      <div class="card-actions">
+        <a href="{{ path('app_usenet_history', {client: client}) }}" class="btn btn-sm btn-outline-secondary d-inline-flex align-items-center gap-1">
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 8v4l3 3"/><path d="M3.05 11a9 9 0 1 1 .5 4"/><path d="M3 4v5h5"/></svg>
+          {{ 'usenet.history.view_all'|trans({count: history_total}) }}
+        </a>
+      </div>
+    </div>
+    <div class="card-body py-2">
+      <div class="uh-list">
+        {% include 'usenet/_history_rows.html.twig' with {items: recent_history, client: client} only %}
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
   {# ─── Bulk action bar ─────────────────────────────────────────── #}
   <div class="usenet-bulk-bar" data-usenet-bulk-bar>
     <span class="fw-bold" data-usenet-bulk-count></span>

--- a/symfony/templates/usenet/index.html.twig
+++ b/symfony/templates/usenet/index.html.twig
@@ -167,6 +167,8 @@ body[data-bs-theme="dark"] .usenet-view-switcher { background:rgba(255,255,255,.
 .usenet-prop-label { font-size:.66rem; color:var(--tblr-text-secondary); text-transform:uppercase; letter-spacing:.3px; font-weight:600; margin-bottom:3px; }
 .usenet-prop-value { font-size:.84rem; font-weight:600; color:var(--tblr-body-color); word-break:break-word; }
 </style>
+{# .uh-* rules for the "Recent history" rows — shared with the history page. #}
+{% include 'usenet/_history_styles.html.twig' %}
 {% endblock %}
 
 {% block body %}

--- a/symfony/tests/Controller/UsenetControllerTest.php
+++ b/symfony/tests/Controller/UsenetControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\Controller;
 
+use App\Controller\UsenetController;
 use App\Entity\Setting;
 use App\Service\HealthService;
 use App\Service\Media\Usenet\SabnzbdClient;
@@ -10,6 +11,7 @@ use App\Service\Media\Usenet\UsenetStatus;
 use App\Tests\AbstractWebTestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Contracts\Cache\CacheInterface;
 
 /**
  * #20 — a configured-but-unreachable Usenet client must show an explicit
@@ -22,6 +24,19 @@ use PHPUnit\Framework\MockObject\MockObject;
 #[AllowMockObjectsWithoutExpectations]
 class UsenetControllerTest extends AbstractWebTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The recent-history preview is cached in the app pool (filesystem in
+        // the test env), which outlives a single test — drop both clients' keys
+        // so no test inherits another's cached history.
+        $cache = static::getContainer()->get(CacheInterface::class);
+        foreach (['sabnzbd', 'nzbget'] as $kind) {
+            $cache->delete(UsenetController::recentHistoryCacheKey($kind));
+        }
+    }
+
     public function testUnreachableSabnzbdShowsErrorBanner(): void
     {
         $em = $this->em();
@@ -104,7 +119,9 @@ class UsenetControllerTest extends AbstractWebTestCase
     {
         $sab = $this->configureSabnzbd();
         $this->mockHealthy();
-        $sab->method('getHistoryPage')->willReturn([
+        // Pin the fetch window: 15 rows from offset 0. That limit governs the
+        // per-render cost, especially on NZBGet (no upstream paging).
+        $sab->expects($this->once())->method('getHistoryPage')->with(0, 15)->willReturn([
             'items' => [
                 $this->historyItem('Recent.One', UsenetStatus::COMPLETED, 1755800000),
                 $this->historyItem('Recent.Two', UsenetStatus::FAILED),
@@ -143,7 +160,9 @@ class UsenetControllerTest extends AbstractWebTestCase
 
         $this->assertSame(200, $this->client->getResponse()->getStatusCode());
         $this->assertStringNotContainsString('Recent history', $html);
-        $this->assertStringNotContainsString('uh-row', $html);
+        // Match the markup, not the bare class name — the .uh-* stylesheet is
+        // included unconditionally, so "uh-row" also appears in the CSS.
+        $this->assertStringNotContainsString('class="uh-row"', $html);
         $this->assertStringContainsString('data-stat="active"', $html);
     }
 
@@ -158,6 +177,58 @@ class UsenetControllerTest extends AbstractWebTestCase
 
         $this->assertSame(200, $this->client->getResponse()->getStatusCode());
         $this->assertStringNotContainsString('Recent history', (string) $this->client->getResponse()->getContent());
+    }
+
+    public function testRecentHistoryIsFetchedOncePerCacheWindow(): void
+    {
+        // NZBGet's history RPC has no upstream paging — getHistoryPage() pulls
+        // the WHOLE retained history and slices locally. Without a short cache
+        // that unbounded payload would cross the wire on every page render, so
+        // two renders inside the TTL must cost exactly one client call.
+        $this->client->disableReboot(); // keep the mocks + cache pool across both renders
+        $sab = $this->configureSabnzbd();
+        $this->mockHealthy();
+        $sab->expects($this->once())->method('getHistoryPage')->with(0, 15)->willReturn([
+            'items' => [$this->historyItem('Cached.Release', UsenetStatus::COMPLETED, 1755800000)],
+            'total' => 7,
+        ]);
+
+        $this->client->request('GET', '/usenet/sabnzbd');
+        $first = (string) $this->client->getResponse()->getContent();
+        $this->client->request('GET', '/usenet/sabnzbd');
+        $second = (string) $this->client->getResponse()->getContent();
+
+        // Both renders show the rows — the second one out of the cache, which
+        // also proves the UsenetDownload DTOs survive a round-trip through the
+        // pool.
+        $this->assertStringContainsString('Cached.Release', $first);
+        $this->assertStringContainsString('Cached.Release', $second);
+        $this->assertStringContainsString('View all (7)', $second);
+    }
+
+    public function testFailedHistoryFetchIsNotCached(): void
+    {
+        // A transient failure must not be pinned for the whole TTL: the next
+        // render retries (mirrors MediaLibraryCache's "empty is not cached").
+        $this->client->disableReboot();
+        $sab = $this->configureSabnzbd();
+        $this->mockHealthy();
+        $calls = 0;
+        $sab->method('getHistoryPage')->willReturnCallback(function () use (&$calls) {
+            if (++$calls === 1) {
+                throw new \RuntimeException('boom');
+            }
+            return ['items' => [$this->historyItem('Retried.Release', UsenetStatus::COMPLETED)], 'total' => 1];
+        });
+
+        $this->client->request('GET', '/usenet/sabnzbd');
+        $first = (string) $this->client->getResponse()->getContent();
+        $this->client->request('GET', '/usenet/sabnzbd');
+        $second = (string) $this->client->getResponse()->getContent();
+
+        $this->assertStringNotContainsString('Recent history', $first);
+        $this->assertStringContainsString('Retried.Release', $second);
+        $this->assertSame(2, $calls);
     }
 
     /** Make the render-time probe report a healthy client. */

--- a/symfony/tests/Controller/UsenetControllerTest.php
+++ b/symfony/tests/Controller/UsenetControllerTest.php
@@ -98,6 +98,77 @@ class UsenetControllerTest extends AbstractWebTestCase
         $this->assertTrue($this->client->getResponse()->isRedirect());
     }
 
+    // ── Recent history on the downloads page (#47) ────────────────────────────
+
+    public function testDownloadsPageRendersRecentHistory(): void
+    {
+        $sab = $this->configureSabnzbd();
+        $this->mockHealthy();
+        $sab->method('getHistoryPage')->willReturn([
+            'items' => [
+                $this->historyItem('Recent.One', UsenetStatus::COMPLETED, 1755800000),
+                $this->historyItem('Recent.Two', UsenetStatus::FAILED),
+            ],
+            'total' => 42,
+        ]);
+
+        $this->client->request('GET', '/usenet/sabnzbd');
+        $html = (string) $this->client->getResponse()->getContent();
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        // The section, its rows and the "view all" link (with the grand total)
+        // must all be server-rendered — no poller fills this in.
+        $this->assertStringContainsString('Recent history', $html);
+        $this->assertStringContainsString('Recent.One', $html);
+        $this->assertStringContainsString('Recent.Two', $html);
+        $this->assertStringContainsString('class="uh-row" data-status="completed"', $html);
+        $this->assertStringContainsString('View all (42)', $html);
+        $this->assertStringContainsString('/usenet/sabnzbd/history', $html);
+        // Two age cells; exactly one falls back to the em dash, so the dated
+        // row really rendered a relative label (locale-independent assertion).
+        $this->assertSame(2, substr_count($html, 'class="uh-age"'));
+        $this->assertSame(1, substr_count($html, 'class="uh-age">—</div>'));
+    }
+
+    public function testDownloadsPageSurvivesHistoryFailure(): void
+    {
+        // A history call that blows up must not take the whole page with it —
+        // the queue still renders and the section is simply absent.
+        $sab = $this->configureSabnzbd();
+        $this->mockHealthy();
+        $sab->method('getHistoryPage')->willThrowException(new \RuntimeException('boom'));
+
+        $this->client->request('GET', '/usenet/sabnzbd');
+        $html = (string) $this->client->getResponse()->getContent();
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertStringNotContainsString('Recent history', $html);
+        $this->assertStringNotContainsString('uh-row', $html);
+        $this->assertStringContainsString('data-stat="active"', $html);
+    }
+
+    public function testUnreachableClientSkipsHistoryFetch(): void
+    {
+        // The probe already failed → the page shows its banner; a doomed
+        // history call would only burn the connect timeout.
+        $sab = $this->configureSabnzbd();
+        $sab->expects($this->never())->method('getHistoryPage');
+
+        $this->client->request('GET', '/usenet/sabnzbd');
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertStringNotContainsString('Recent history', (string) $this->client->getResponse()->getContent());
+    }
+
+    /** Make the render-time probe report a healthy client. */
+    private function mockHealthy(): void
+    {
+        $health = $this->createMock(HealthService::class);
+        $health->method('isConfigured')->willReturn(true);
+        $health->method('diagnose')->willReturn(['ok' => true, 'category' => 'ok', 'http' => 200]);
+        static::getContainer()->set(HealthService::class, $health);
+    }
+
     // ── History page ─────────────────────────────────────────────────────────
 
     public function testHistoryPageRendersItems(): void
@@ -137,12 +208,13 @@ class UsenetControllerTest extends AbstractWebTestCase
         $this->assertTrue($this->client->getResponse()->isRedirect());
     }
 
-    private function historyItem(string $name, string $status): UsenetDownload
+    private function historyItem(string $name, string $status, ?int $completedAt = null): UsenetDownload
     {
         return new UsenetDownload(
             id: 'x', name: $name, status: $status, rawStatus: 'Completed',
             sizeBytes: 1048576, remainingBytes: 0, percentage: 100.0, category: 'movies',
             etaSeconds: null, speedBytes: 0, failMessage: null, isHistory: true,
+            completedAt: $completedAt,
         );
     }
 

--- a/symfony/tests/Service/Media/Usenet/NzbgetClientTest.php
+++ b/symfony/tests/Service/Media/Usenet/NzbgetClientTest.php
@@ -127,6 +127,34 @@ class NzbgetClientTest extends TestCase
         self::assertNull($d->failMessage);
     }
 
+    public function testNormalizeHistoryExposesHistoryTimeAsCompletedAt(): void
+    {
+        // NZBGet stamps each history entry with HistoryTime (unix epoch) — the
+        // moment it landed in history, i.e. when the job finished (#47).
+        /** @var UsenetDownload $d */
+        $d = $this->call('normalizeHistory', [
+            'NZBID'       => 9,
+            'Name'        => 'Timed.Release',
+            'Status'      => 'SUCCESS/ALL',
+            'FileSizeMB'  => 10,
+            'HistoryTime' => 1755800000,
+        ]);
+
+        self::assertSame(1755800000, $d->completedAt);
+    }
+
+    public function testNormalizeHistoryWithoutHistoryTimeIsNull(): void
+    {
+        /** @var UsenetDownload $d */
+        $d = $this->call('normalizeHistory', [
+            'NZBID'  => 10,
+            'Name'   => 'Undated.Release',
+            'Status' => 'SUCCESS/ALL',
+        ]);
+
+        self::assertNull($d->completedAt);
+    }
+
     public function testGetKind(): void
     {
         self::assertSame('nzbget', $this->makeClient()->getKind());

--- a/symfony/tests/Service/Media/Usenet/SabnzbdClientTest.php
+++ b/symfony/tests/Service/Media/Usenet/SabnzbdClientTest.php
@@ -98,6 +98,38 @@ class SabnzbdClientTest extends TestCase
         self::assertNull($d->failMessage);
     }
 
+    public function testHistorySlotExposesCompletionTimestamp(): void
+    {
+        // SABnzbd stamps each history slot with `completed` (unix epoch); the
+        // downloads page renders it as a relative "age" label (#47).
+        /** @var UsenetDownload $d */
+        $d = $this->call('normalizeHistorySlot', [
+            'nzo_id'    => 'x',
+            'name'      => 'n',
+            'status'    => 'Completed',
+            'bytes'     => 100,
+            'completed' => 1755800000,
+        ]);
+
+        self::assertSame(1755800000, $d->completedAt);
+    }
+
+    public function testHistorySlotWithoutCompletionTimestampIsNull(): void
+    {
+        // An older SABnzbd (or a partial slot) may omit `completed` — the field
+        // must read null, never 0, so the UI can fall back instead of printing
+        // "1970".
+        /** @var UsenetDownload $d */
+        $d = $this->call('normalizeHistorySlot', [
+            'nzo_id' => 'x',
+            'name'   => 'n',
+            'status' => 'Completed',
+            'bytes'  => 100,
+        ]);
+
+        self::assertNull($d->completedAt);
+    }
+
     /** @return array<string, array{string, ?int}> */
     public static function clockProvider(): array
     {

--- a/symfony/translations/messages+intl-icu.en.yaml
+++ b/symfony/translations/messages+intl-icu.en.yaml
@@ -4302,6 +4302,8 @@ usenet:
     prev: Previous
     next: Next
     page_of: 'Page {current} / {total}'
+    recent_title: 'Recent history'
+    view_all: 'View all ({count})'
   empty: 'The queue is empty.'
   toolbar:
     pause_all: Pause all

--- a/symfony/translations/messages+intl-icu.fr.yaml
+++ b/symfony/translations/messages+intl-icu.fr.yaml
@@ -4300,6 +4300,8 @@ usenet:
     prev: Précédent
     next: Suivant
     page_of: 'Page {current} / {total}'
+    recent_title: 'Historique récent'
+    view_all: 'Tout voir ({count})'
   empty: 'La file est vide.'
   toolbar:
     pause_all: Tout mettre en pause


### PR DESCRIPTION
Fixes #47.

Adds a server-rendered **Recent history** section (latest 15, compact one-line rows: name + category/status/size pills + a new age pill) below the queue on the downloads page, with a "View all" link to the full paginated history page. Works for both SABnzbd and NZBGet.

Implementation notes:

- `UsenetDownload` gains a nullable `completedAt` epoch, mapped from SABnzbd's `completed` and NZBGet's `HistoryTime`; the age pill renders via the existing `relative_date` filter and falls back to an em dash when unknown. (This also adds the age line to the history page itself.)
- The history rows are extracted into a shared `_history_rows.html.twig` partial; the `.uh-*` CSS moves to `_history_styles.html.twig`, included from both pages' `stylesheets` block.
- The recent-history fetch sits behind a **45s per-client cache** (empty results and failures aren't cached). This matters for NZBGet, where `getHistoryPage()` is a full-history RPC transfer sliced locally — without the cache every downloads-page render would re-transfer the entire retained history. The paginated history page stays uncached/live.
- On a failed fetch the section simply doesn't render (the page keeps its normal error banners).

Tests: completedAt mapping units for both clients; render, arg-pinning (`->with(0, 15)`), cache short-circuit (two renders → one client call), and error-path functional tests. 48 tests / 132 assertions green, `lint:twig` + `lint:yaml` clean, EN+FR keys included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)