### PR TITLE
Honor the Display date/time preference everywhere

### DIFF
--- a/symfony/src/Service/DisplayPreferencesService.php
+++ b/symfony/src/Service/DisplayPreferencesService.php
@@ -135,27 +135,34 @@ class DisplayPreferencesService implements ResetInterface
 
     /**
      * Formatted time string according to the user's chosen time format.
+     *
+     * $withSeconds is opt-in so the common case stays "14:30" / "2:30 PM";
+     * log and command tables that genuinely need second precision pass true.
      */
-    public function formatTime(?\DateTimeInterface $dt): ?string
+    public function formatTime(?\DateTimeInterface $dt, bool $withSeconds = false): ?string
     {
         if ($dt === null) {
             return null;
         }
         $dt = $this->toUserTimezone($dt);
 
-        return $this->getTimeFormat() === '12h' ? $dt->format('g:i A') : $dt->format('H:i');
+        $fmt = $this->getTimeFormat() === '12h'
+            ? ($withSeconds ? 'g:i:s A' : 'g:i A')
+            : ($withSeconds ? 'H:i:s' : 'H:i');
+
+        return $dt->format($fmt);
     }
 
     /**
      * Date + time combined, honoring both format preferences.
      */
-    public function formatDateTime(?\DateTimeInterface $dt): ?string
+    public function formatDateTime(?\DateTimeInterface $dt, bool $withSeconds = false): ?string
     {
         if ($dt === null) {
             return null;
         }
 
-        return $this->formatDate($dt) . ' · ' . $this->formatTime($dt);
+        return $this->formatDate($dt) . ' · ' . $this->formatTime($dt, $withSeconds);
     }
 
     private function toUserTimezone(\DateTimeInterface $dt): \DateTimeImmutable

--- a/symfony/src/Twig/DisplayPreferencesExtension.php
+++ b/symfony/src/Twig/DisplayPreferencesExtension.php
@@ -17,6 +17,7 @@ use Twig\TwigFunction;
  *   {{ item.date|prismarr_date }}            {# "21/04/2026" (per user format) #}
  *   {{ item.date|prismarr_time }}            {# "14:30" or "2:30 PM" #}
  *   {{ item.date|prismarr_datetime }}        {# "21/04/2026 · 14:30" #}
+ *   {{ item.date|prismarr_datetime(true) }}  {# "21/04/2026 · 14:30:07" (seconds) #}
  */
 class DisplayPreferencesExtension extends AbstractExtension
 {
@@ -129,14 +130,16 @@ class DisplayPreferencesExtension extends AbstractExtension
         return $this->prefs->formatDate($this->asDateTime($dt));
     }
 
-    public function filterTime(mixed $dt): ?string
+    /** `{{ d|prismarr_time }}` → "14:30"; `{{ d|prismarr_time(true) }}` → "14:30:07". */
+    public function filterTime(mixed $dt, bool $withSeconds = false): ?string
     {
-        return $this->prefs->formatTime($this->asDateTime($dt));
+        return $this->prefs->formatTime($this->asDateTime($dt), $withSeconds);
     }
 
-    public function filterDateTime(mixed $dt): ?string
+    /** `{{ d|prismarr_datetime(true) }}` adds seconds to the time half. */
+    public function filterDateTime(mixed $dt, bool $withSeconds = false): ?string
     {
-        return $this->prefs->formatDateTime($this->asDateTime($dt));
+        return $this->prefs->formatDateTime($this->asDateTime($dt), $withSeconds);
     }
 
     public function pref(string $key): mixed

--- a/symfony/templates/base.html.twig
+++ b/symfony/templates/base.html.twig
@@ -63,6 +63,44 @@
       };
     }
 
+    // Global preference-aware date/time formatters (#54) — the JS mirror of the
+    // |prismarr_date / |prismarr_time / |prismarr_datetime Twig filters, so rows
+    // rebuilt by a poller read the same as the server-rendered ones instead of
+    // falling back to the UI locale (or a hardcoded fr-FR).
+    //
+    // Defined here in <head> for exactly the reason prismarrBytes is above: the
+    // child templates' "javascripts" block renders far higher up the body than
+    // the page-lifecycle script near the end of this template, and callers such
+    // as films.html.twig's renderQueue() run during the initial parse — a later
+    // definition would race with the first call.
+    //
+    // These take a JS Date, so the zone is the browser's. That matches the
+    // pre-existing client-side behaviour; only the *format* becomes a
+    // preference. The server-side filters remain the timezone-aware path.
+    if (!window._prismarrFmtDate) {
+      window._prismarrDatePrefs = {
+        date: {{ display_pref('date_format')|json_encode|raw }},
+        time: {{ display_pref('time_format')|json_encode|raw }}
+      };
+      window._prismarrFmtDate = function (d) {
+        var p = window._prismarrDatePrefs || {};
+        if (p.date === 'iso') {
+          var m = ('0' + (d.getMonth() + 1)).slice(-2), day = ('0' + d.getDate()).slice(-2);
+          return d.getFullYear() + '-' + m + '-' + day;
+        }
+        return d.toLocaleDateString(p.date === 'us' ? 'en-US' : 'fr-FR');
+      };
+      window._prismarrFmtTime = function (d, withSeconds) {
+        var p = window._prismarrDatePrefs || {};
+        var opts = { hour: '2-digit', minute: '2-digit', hour12: p.time === '12h' };
+        if (withSeconds) opts.second = '2-digit';
+        return d.toLocaleTimeString(p.time === '12h' ? 'en-US' : 'fr-FR', opts);
+      };
+      window._prismarrFmtDateTime = function (d, withSeconds) {
+        return window._prismarrFmtDate(d) + ' ' + window._prismarrFmtTime(d, withSeconds);
+      };
+    }
+
     // HTML escape helper used wherever JS builds strings via innerHTML with
     // operator-side-controlled values (instance names, search results titles,
     // upstream messages). Self-XSS today (ROLE_ADMIN is the only writer for

--- a/symfony/templates/base.html.twig
+++ b/symfony/templates/base.html.twig
@@ -82,22 +82,40 @@
         date: {{ display_pref('date_format')|json_encode|raw }},
         time: {{ display_pref('time_format')|json_encode|raw }}
       };
+      // An unparseable payload yields an Invalid Date; callers only guard
+      // truthiness, so return the pages' em-dash placeholder rather than
+      // "NaN-NaN-NaN" / "Invalid Date".
       window._prismarrFmtDate = function (d) {
+        if (isNaN(d.getTime())) return '—';
         var p = window._prismarrDatePrefs || {};
         if (p.date === 'iso') {
           var m = ('0' + (d.getMonth() + 1)).slice(-2), day = ('0' + d.getDate()).slice(-2);
           return d.getFullYear() + '-' + m + '-' + day;
         }
-        return d.toLocaleDateString(p.date === 'us' ? 'en-US' : 'fr-FR');
+        // 'us' mirrors formatDate()'s 'M j, Y' → "Apr 21, 2026", not en-US's
+        // default numeric 4/21/2026.
+        if (p.date === 'us') {
+          return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+        }
+        return d.toLocaleDateString('fr-FR');
       };
       window._prismarrFmtTime = function (d, withSeconds) {
+        if (isNaN(d.getTime())) return '—';
         var p = window._prismarrDatePrefs || {};
-        var opts = { hour: '2-digit', minute: '2-digit', hour12: p.time === '12h' };
+        // 12h uses a bare hour to match PHP 'g' ("2:30 PM"); 24h pads to match 'H'.
+        var opts = {
+          hour: p.time === '12h' ? 'numeric' : '2-digit',
+          minute: '2-digit',
+          hour12: p.time === '12h'
+        };
         if (withSeconds) opts.second = '2-digit';
         return d.toLocaleTimeString(p.time === '12h' ? 'en-US' : 'fr-FR', opts);
       };
+      // ' · ' is the separator formatDateTime() uses server-side — the two must
+      // agree, since a poller can rewrite an element Twig already rendered.
       window._prismarrFmtDateTime = function (d, withSeconds) {
-        return window._prismarrFmtDate(d) + ' ' + window._prismarrFmtTime(d, withSeconds);
+        if (isNaN(d.getTime())) return '—';
+        return window._prismarrFmtDate(d) + ' · ' + window._prismarrFmtTime(d, withSeconds);
       };
     }
 

--- a/symfony/templates/base.html.twig
+++ b/symfony/templates/base.html.twig
@@ -77,11 +77,17 @@
     // These take a JS Date, so the zone is the browser's. That matches the
     // pre-existing client-side behaviour; only the *format* becomes a
     // preference. The server-side filters remain the timezone-aware path.
+
+    // The prefs payload is re-stamped on EVERY document, outside the guard below:
+    // after an admin changes the Display preference, a Turbo-navigated page must
+    // not keep serving the old format from a stale global while the
+    // server-rendered dates around it have already updated. The function bodies
+    // are pure, so those stay guarded and are defined once.
+    window._prismarrDatePrefs = {
+      date: {{ display_pref('date_format')|json_encode|raw }},
+      time: {{ display_pref('time_format')|json_encode|raw }}
+    };
     if (!window._prismarrFmtDate) {
-      window._prismarrDatePrefs = {
-        date: {{ display_pref('date_format')|json_encode|raw }},
-        time: {{ display_pref('time_format')|json_encode|raw }}
-      };
       // An unparseable payload yields an Invalid Date; callers only guard
       // truthiness, so return the pages' em-dash placeholder rather than
       // "NaN-NaN-NaN" / "Invalid Date".

--- a/symfony/templates/dashboard/_quicklook_body.html.twig
+++ b/symfony/templates/dashboard/_quicklook_body.html.twig
@@ -30,7 +30,7 @@
         {% for d in ql.releaseDates|default([]) %}
           <span class="ql-date{% if d.upcoming %} is-upcoming{% endif %}">
             <span class="ql-date-label">{{ d.label }}</span>
-            <span class="ql-date-val">{{ d.date|date('M j, Y') }}</span>
+            <span class="ql-date-val">{{ d.date|prismarr_date }}</span>
           </span>
         {% endfor %}
       </div>

--- a/symfony/templates/deluge/index.html.twig
+++ b/symfony/templates/deluge/index.html.twig
@@ -810,7 +810,6 @@ body[data-bs-theme="dark"] .qbt-torrent-list[data-view="table"] .qbt-cell-progre
 <script>
 (function(){
     var BASE = '{{ path("app_deluge_index") }}';
-    var LOCALE = {{ app.request.locale|default('fr')|json_encode|raw }};
     var currentFilter = 'all';
     var selectedHashes = {};
     var deleteTarget = { hashes: [], mode: 'single' };

--- a/symfony/templates/deluge/index.html.twig
+++ b/symfony/templates/deluge/index.html.twig
@@ -1370,14 +1370,11 @@ body[data-bs-theme="dark"] .qbt-torrent-list[data-view="table"] .qbt-cell-progre
     }
     function fmtShortDate(ts) {
         if (!ts) return '—';
-        var d = new Date(ts * 1000);
-        return ('0' + d.getDate()).slice(-2) + '/' + ('0' + (d.getMonth() + 1)).slice(-2) + '/' + String(d.getFullYear()).slice(-2);
+        return window._prismarrFmtDate(new Date(ts * 1000));
     }
     function fmtLongDate(ts) {
         if (!ts) return '—';
-        var d = new Date(ts * 1000);
-        return ('0' + d.getDate()).slice(-2) + '/' + ('0' + (d.getMonth() + 1)).slice(-2) + '/' + d.getFullYear()
-            + ' ' + ('0' + d.getHours()).slice(-2) + ':' + ('0' + d.getMinutes()).slice(-2);
+        return window._prismarrFmtDateTime(new Date(ts * 1000));
     }
 
     function buildStatsLine(t) {

--- a/symfony/templates/deluge/index.html.twig
+++ b/symfony/templates/deluge/index.html.twig
@@ -992,9 +992,7 @@ body[data-bs-theme="dark"] .qbt-torrent-list[data-view="table"] .qbt-cell-progre
     }
     function fmtDate(ts) {
         if (!ts || ts < 0) return '-';
-        var d = new Date(ts * 1000);
-        var loc = (LOCALE === 'en') ? 'en-US' : 'fr-FR';
-        return d.toLocaleDateString(loc) + ' ' + d.toLocaleTimeString(loc, {hour:'2-digit',minute:'2-digit'});
+        return window._prismarrFmtDateTime(new Date(ts * 1000));
     }
     function escapeHtml(s) { return String(s == null ? '' : s).replace(/[&<>"']/g, function(c){ return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]; }); }
 

--- a/symfony/templates/deluge/index.html.twig
+++ b/symfony/templates/deluge/index.html.twig
@@ -775,7 +775,7 @@ body[data-bs-theme="dark"] .qbt-torrent-list[data-view="table"] .qbt-cell-progre
             <span class="item" title="{{ 'deluge.row.title_ratio'|trans }}">{{ ico.icon('scale', '', 14) }} {{ (t.ratio ?? 0)|number_format(2) }}</span>
             {% if t.added_on %}
             <span class="sep"></span>
-            <span class="item" title="{{ 'deluge.row.title_added_tpl'|trans|replace({'__DATE__': t.added_on|date('d/m/Y H:i')}) }}">{{ ico.icon('calendar', '', 14) }} {{ t.added_on|date('d/m/y') }}</span>
+            <span class="item" title="{{ 'deluge.row.title_added_tpl'|trans|replace({'__DATE__': t.added_on|prismarr_datetime}) }}">{{ ico.icon('calendar', '', 14) }} {{ t.added_on|prismarr_date }}</span>
             {% endif %}
         </div>
     </div>
@@ -789,7 +789,7 @@ body[data-bs-theme="dark"] .qbt-torrent-list[data-view="table"] .qbt-cell-progre
     <div class="qbt-table-cell">{{ (t.ratio ?? 0)|number_format(2) }}</div>
     <div class="qbt-table-cell qbt-cell-uploaded">{{ t.uploaded|prismarr_bytes }}</div>
     <div class="qbt-table-cell qbt-cell-completed">{{ t.completion_on ? (t.completion_on|prismarr_date) : '—' }}</div>
-    <div class="qbt-table-cell qbt-cell-added" data-added="{{ t.added_on ?? 0 }}">{% if t.added_on %}{{ t.added_on|date('d/m/y') }}{% else %}—{% endif %}</div>
+    <div class="qbt-table-cell qbt-cell-added" data-added="{{ t.added_on ?? 0 }}">{% if t.added_on %}{{ t.added_on|prismarr_date }}{% else %}—{% endif %}</div>
 
     {# Cellule mode compact — % seul #}
     <div class="qbt-compact-pct">{{ t.progress }}%</div>

--- a/symfony/templates/jellyseerr/settings/logs.html.twig
+++ b/symfony/templates/jellyseerr/settings/logs.html.twig
@@ -44,7 +44,7 @@
                     <tr data-level="{{ lvl }}">
                         <td class="text-muted small" style="font-family:monospace;font-size:.72rem;">
                             {% if log.timestamp is defined %}
-                                {{ log.timestamp|date('d/m H:i:s') }}
+                                {{ log.timestamp|prismarr_datetime(true) }}
                             {% else %}—{% endif %}
                         </td>
                         <td>

--- a/symfony/templates/jellyseerr/settings/tasks_cache.html.twig
+++ b/symfony/templates/jellyseerr/settings/tasks_cache.html.twig
@@ -55,7 +55,7 @@
                         </button>
                     </td>
                     <td class="text-muted small" id="next-{{ job.id }}">
-                        {% if job.nextExecutionTime %}{{ job.nextExecutionTime|date('d/m/Y H:i') }}{% else %}—{% endif %}
+                        {% if job.nextExecutionTime %}{{ job.nextExecutionTime|prismarr_datetime }}{% else %}—{% endif %}
                     </td>
                     <td>
                         <span id="status-{{ job.id }}" class="badge {{ job.running ?? false ? 'bg-purple-lt text-purple js-running' : 'bg-green-lt text-green' }}">

--- a/symfony/templates/jellyseerr/settings/tasks_cache.html.twig
+++ b/symfony/templates/jellyseerr/settings/tasks_cache.html.twig
@@ -302,7 +302,7 @@
                 if (d.ok && d.job && d.job.nextExecutionTime) {
                     var dt = new Date(d.job.nextExecutionTime);
                     var nextEl = document.getElementById('next-' + jobId);
-                    if (nextEl) nextEl.textContent = dt.toLocaleDateString('fr-FR') + ' ' + dt.toLocaleTimeString('fr-FR', {hour:'2-digit',minute:'2-digit'});
+                    if (nextEl) nextEl.textContent = window._prismarrFmtDateTime(dt);
                 }
                 setTimeout(function(){ location.reload(); }, 3000);
             })
@@ -536,7 +536,7 @@
                 if (d.job && d.job.nextExecutionTime) {
                     var dt = new Date(d.job.nextExecutionTime);
                     var nextEl = document.getElementById('next-' + jobId);
-                    if (nextEl) nextEl.textContent = dt.toLocaleDateString('fr-FR') + ' ' + dt.toLocaleTimeString('fr-FR', {hour:'2-digit',minute:'2-digit'});
+                    if (nextEl) nextEl.textContent = window._prismarrFmtDateTime(dt);
                 }
             }
             cronSave.disabled = false;

--- a/symfony/templates/jellyseerr/settings/updates.html.twig
+++ b/symfony/templates/jellyseerr/settings/updates.html.twig
@@ -72,7 +72,7 @@
                                 {% endif %}
                             </td>
                             <td class="text-muted small">
-                                {% if rel.date %}{{ rel.date|date('d/m/Y') }}{% else %}—{% endif %}
+                                {% if rel.date %}{{ rel.date|prismarr_date }}{% else %}—{% endif %}
                             </td>
                             <td>
                                 {% if rel.current %}

--- a/symfony/templates/media/films.html.twig
+++ b/symfony/templates/media/films.html.twig
@@ -2070,7 +2070,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
 
       items.slice(0, 15).forEach(function (item) {
         var evType  = item.eventType || '';
-        var date    = item.date ? new Date(item.date).toLocaleDateString('fr-FR') + ' ' + new Date(item.date).toLocaleTimeString('fr-FR', {hour:'2-digit',minute:'2-digit'}) : '—';
+        var date    = item.date ? window._prismarrFmtDateTime(new Date(item.date)) : '—';
         var quality = (item.quality && item.quality.quality) ? item.quality.quality.name : '';
         var source  = (item.data && item.data.releaseTitle) ? item.data.releaseTitle : ((item.data && item.data.importedPath) ? item.data.importedPath : '');
         var lbl     = evLabel[evType] || evType;
@@ -3478,7 +3478,7 @@ body.density-compact #modal-film .film-action-btn { font-size: .78rem; padding: 
           '<div class="queue-progress flex-grow-1"><div class="queue-progress-bar" style="width:' + pct + '%"></div></div>' +
           '<span class="text-muted small">' + pct + '%</span></div>' +
           '<div class="text-muted" style="font-size:.7rem">' + sizeLabel +
-          (q.eta ? FILM_I18N.q_eta_prefix + new Date(q.eta).toLocaleTimeString(document.documentElement.lang || 'fr-FR', {hour:'2-digit',minute:'2-digit'}) : '') + '</div>';
+          (q.eta ? FILM_I18N.q_eta_prefix + window._prismarrFmtTime(new Date(q.eta)) : '') + '</div>';
       }
 
       // Status badge — import state takes priority over DL status

--- a/symfony/templates/media/films_blocklist.html.twig
+++ b/symfony/templates/media/films_blocklist.html.twig
@@ -56,7 +56,7 @@
           </td>
           <td class="text-muted small text-nowrap">
             {% if item.date is defined %}
-              {{ item.date|date('d/m/Y H:i') }}
+              {{ item.date|prismarr_datetime }}
             {% else %}
               —
             {% endif %}

--- a/symfony/templates/media/films_cutoff.html.twig
+++ b/symfony/templates/media/films_cutoff.html.twig
@@ -66,7 +66,7 @@
           </td>
           <td class="text-muted small">
             {% if m.inCinemas is defined and m.inCinemas %}
-              {{ m.inCinemas|date('d/m/Y') }}
+              {{ m.inCinemas|prismarr_date }}
             {% else %}
               —
             {% endif %}

--- a/symfony/templates/media/films_history.html.twig
+++ b/symfony/templates/media/films_history.html.twig
@@ -64,7 +64,7 @@
         <tr>
           <td class="text-muted small text-nowrap">
             {% if item.date is defined %}
-              {{ item.date|date('d/m/Y H:i') }}
+              {{ item.date|prismarr_datetime }}
             {% else %}
               —
             {% endif %}

--- a/symfony/templates/media/films_missing.html.twig
+++ b/symfony/templates/media/films_missing.html.twig
@@ -81,9 +81,9 @@
           </td>
           <td class="text-muted" style="font-size:.78rem;">
             {% if m.digitalRelease is defined and m.digitalRelease %}
-              {{ m.digitalRelease|date('d/m/Y') }}
+              {{ m.digitalRelease|prismarr_date }}
             {% elseif m.inCinemas is defined and m.inCinemas %}
-              {{ m.inCinemas|date('d/m/Y') }}
+              {{ m.inCinemas|prismarr_date }}
             {% else %}
               —
             {% endif %}

--- a/symfony/templates/media/indexeurs.html.twig
+++ b/symfony/templates/media/indexeurs.html.twig
@@ -140,7 +140,7 @@
         {% for s in searches %}
           <tr>
             <td class="text-muted small text-nowrap">
-              {{ s.date ? s.date|date('d/m H:i') : '—' }}
+              {{ s.date ? s.date|prismarr_datetime : '—' }}
             </td>
             <td class="small">{{ s.indexer }}</td>
             <td class="small text-truncate" style="max-width:300px;" title="{{ s.query }}">{{ s.query }}</td>

--- a/symfony/templates/media/radarr_system.html.twig
+++ b/symfony/templates/media/radarr_system.html.twig
@@ -47,7 +47,7 @@
 
           {% if status.startTime is defined %}
           <dt class="col-5 text-muted small">{{ 'media.arr_system.status.started'|trans }}</dt>
-          <dd class="col-7 small mb-0">{{ status.startTime|date('d/m/Y H:i') }}</dd>
+          <dd class="col-7 small mb-0">{{ status.startTime|prismarr_datetime }}</dd>
           {% endif %}
 
           <dt class="col-5 text-muted small">{{ 'media.arr_system.status.url_base'|trans }}</dt>
@@ -274,7 +274,7 @@
         {% for log in logs %}
           <tr>
             <td class="text-muted small text-nowrap">
-              {% if log.time is defined %}{{ log.time|date('d/m/Y H:i:s') }}{% else %}—{% endif %}
+              {% if log.time is defined %}{{ log.time|prismarr_datetime(true) }}{% else %}—{% endif %}
             </td>
             <td>
               {% set lvl = log.level ?? '' %}

--- a/symfony/templates/media/series.html.twig
+++ b/symfony/templates/media/series.html.twig
@@ -312,7 +312,11 @@ body.density-compact #modal-serie .modal-body .card-header { padding-top: .4rem 
               S{{ '%02d'|format(ep.season) }}E{{ '%02d'|format(ep.episode) }} — {{ ep.title }}
             </td>
             <td class="text-muted" style="font-size:.78rem;">
-              {% if ep.airDate %}{{ ep.airDate|date('D d/m H:i', 'Europe/Paris') }}{% else %}—{% endif %}
+              {# The weekday is the useful part of an air date, so it survives the
+                 preference sweep (#54) as a separate |date('D') — the date and time
+                 halves go through |prismarr_datetime, which applies the user's
+                 timezone itself, so the hardcoded zone is gone. #}
+              {% if ep.airDate %}{{ ep.airDate|date('D', display_pref('timezone')) }} {{ ep.airDate|prismarr_datetime }}{% else %}—{% endif %}
             </td>
             <td>
               {% if ep.hasFile %}

--- a/symfony/templates/media/series_blocklist.html.twig
+++ b/symfony/templates/media/series_blocklist.html.twig
@@ -50,7 +50,7 @@
               <span class="badge bg-blue-lt">{{ b.quality.quality.name }}</span>
             {% else %}—{% endif %}
           </td>
-          <td class="text-muted">{{ b.date ? b.date|date('d/m/Y H:i', 'Europe/Paris') : '—' }}</td>
+          <td class="text-muted">{{ b.date ? b.date|prismarr_datetime : '—' }}</td>
           <td class="text-end">
             <button class="btn btn-ghost-danger btn-icon btn-sm btn-blocklist-del" data-id="{{ b.id }}" title="{{ 'media.series_blocklist.delete'|trans }}">
               <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>

--- a/symfony/templates/media/series_history.html.twig
+++ b/symfony/templates/media/series_history.html.twig
@@ -59,7 +59,7 @@
               <span class="badge bg-blue-lt">{{ h.quality.quality.name }}</span>
             {% else %}—{% endif %}
           </td>
-          <td class="text-muted">{{ h.date ? h.date|date('d/m/Y H:i', 'Europe/Paris') : '—' }}</td>
+          <td class="text-muted">{{ h.date ? h.date|prismarr_datetime : '—' }}</td>
         </tr>
         {% else %}
         <tr><td colspan="6" class="text-center text-muted py-4">{{ 'media.series_history.empty'|trans }}</td></tr>

--- a/symfony/templates/media/sonarr_system.html.twig
+++ b/symfony/templates/media/sonarr_system.html.twig
@@ -39,7 +39,7 @@
           <dd class="col-7 small mb-0">{{ status.databaseVersion ?? '—' }}</dd>
           {% if status.startTime is defined %}
           <dt class="col-5 text-muted small">{{ 'media.arr_system.status.started'|trans }}</dt>
-          <dd class="col-7 small mb-0">{{ status.startTime|date('d/m/Y H:i') }}</dd>
+          <dd class="col-7 small mb-0">{{ status.startTime|prismarr_datetime }}</dd>
           {% endif %}
           <dt class="col-5 text-muted small">{{ 'media.arr_system.status.url_base'|trans }}</dt>
           <dd class="col-7 small mb-0">{{ status.urlBase ?? '/' }}</dd>
@@ -197,7 +197,7 @@
         <tbody>
         {% for log in logs %}
           <tr>
-            <td class="text-muted small text-nowrap">{{ log.time is defined ? log.time|date('d/m/Y H:i:s') : '—' }}</td>
+            <td class="text-muted small text-nowrap">{{ log.time is defined ? log.time|prismarr_datetime(true) : '—' }}</td>
             <td>
               {% if log.level == 'error' or log.level == 'fatal' %}<span class="badge bg-danger-lt">{{ log.level }}</span>
               {% elseif log.level == 'warn' %}<span class="badge bg-warning-lt">{{ log.level }}</span>

--- a/symfony/templates/prowlarr/backups.html.twig
+++ b/symfony/templates/prowlarr/backups.html.twig
@@ -85,7 +85,7 @@
                             </td>
                             <td class="text-muted small">
                                 {% if backup.time is defined %}
-                                    {{ backup.time|date('d/m/Y H:i') }}
+                                    {{ backup.time|prismarr_datetime }}
                                 {% else %}
                                     —
                                 {% endif %}

--- a/symfony/templates/prowlarr/history.html.twig
+++ b/symfony/templates/prowlarr/history.html.twig
@@ -53,7 +53,7 @@
                     {% for r in records %}
                     {% set data = r.data ?? {} %}
                     <tr>
-                        <td class="text-secondary small text-nowrap">{{ r.date is defined and r.date ? r.date|date('d/m H:i') : '—' }}</td>
+                        <td class="text-secondary small text-nowrap">{{ r.date is defined and r.date ? r.date|prismarr_datetime : '—' }}</td>
                         <td>
                             {% if r.eventType is defined %}
                                 {% if r.eventType == 'indexerRss' %}

--- a/symfony/templates/prowlarr/index.html.twig
+++ b/symfony/templates/prowlarr/index.html.twig
@@ -220,7 +220,7 @@
                                     <span class="d-flex align-items-center gap-1 text-success small"><span class="status-dot status-dot-animated bg-success"></span> {{ 'prowlarr.index.status_ok'|trans }}</span>
                                 {% endif %}
                             </td>
-                            <td class="text-secondary small text-nowrap">{{ idx.added ? idx.added|date('d/m/Y') : '—' }}</td>
+                            <td class="text-secondary small text-nowrap">{{ idx.added ? idx.added|prismarr_date : '—' }}</td>
                             <td class="text-end">
                                 <div class="d-flex gap-1 justify-content-end">
                                     <button class="btn btn-sm btn-ghost-secondary p-1" data-edit-id="{{ idx.id }}" title="{{ 'prowlarr.common.edit'|trans }}">

--- a/symfony/templates/prowlarr/index.html.twig
+++ b/symfony/templates/prowlarr/index.html.twig
@@ -1233,8 +1233,7 @@
             var typeBadge = r.eventType === 'indexerRss' ? '<span class="badge bg-cyan-lt" style="font-size:.55rem;">' + esc(_I18N.infoEventRss) + '</span>'
                 : r.eventType === 'indexerQuery' ? '<span class="badge bg-indigo-lt" style="font-size:.55rem;">' + esc(_I18N.infoEventQuery) + '</span>'
                 : '<span class="badge bg-secondary-lt" style="font-size:.55rem;">' + esc(r.eventType || '—') + '</span>';
-            var locale = (document.documentElement.lang || 'fr-FR');
-            h += '<tr class="small"><td class="text-secondary text-nowrap">' + (r.date ? new Date(r.date).toLocaleString(locale, {day:'2-digit',month:'2-digit',hour:'2-digit',minute:'2-digit'}) : '—') + '</td>';
+            h += '<tr class="small"><td class="text-secondary text-nowrap">' + (r.date ? window._prismarrFmtDateTime(new Date(r.date)) : '—') + '</td>';
             h += '<td>' + typeBadge + '</td>';
             h += '<td class="text-truncate" style="max-width:200px;">' + esc(r.data && r.data.query ? r.data.query : '—') + '</td>';
             h += '<td class="text-secondary">' + esc(r.data && r.data.source ? r.data.source : '—') + '</td></tr>';

--- a/symfony/templates/prowlarr/logs.html.twig
+++ b/symfony/templates/prowlarr/logs.html.twig
@@ -58,7 +58,7 @@
                     {% for log in records %}
                     {% set lvl = log.level is defined ? log.level|lower : 'info' %}
                     <tr data-level="{{ lvl }}">
-                        <td class="text-muted small">{{ log.time is defined ? log.time|date('d/m H:i:s') : '—' }}</td>
+                        <td class="text-muted small">{{ log.time is defined ? log.time|prismarr_datetime(true) : '—' }}</td>
                         <td>
                             {% if lvl == 'error' or lvl == 'fatal' %}
                                 <span class="badge bg-danger-lt text-danger">{{ lvl }}</span>

--- a/symfony/templates/prowlarr/system.html.twig
+++ b/symfony/templates/prowlarr/system.html.twig
@@ -39,7 +39,7 @@
                             <tr><td class="text-secondary small">{{ 'prowlarr.system.info_branch'|trans }}</td><td>{{ status.branch ?? '—' }}</td></tr>
                             <tr><td class="text-secondary small">{{ 'prowlarr.system.info_os'|trans }}</td><td>{{ status.osName ?? '—' }} {{ status.osVersion ?? '' }}</td></tr>
                             <tr><td class="text-secondary small">{{ 'prowlarr.system.info_runtime'|trans }}</td><td>{{ status.runtimeName ?? '—' }} {{ status.runtimeVersion ?? '' }}</td></tr>
-                            <tr><td class="text-secondary small">{{ 'prowlarr.system.info_started'|trans }}</td><td>{{ status.startTime ? status.startTime|date('d/m/Y H:i') : '—' }}</td></tr>
+                            <tr><td class="text-secondary small">{{ 'prowlarr.system.info_started'|trans }}</td><td>{{ status.startTime ? status.startTime|prismarr_datetime : '—' }}</td></tr>
                             <tr><td class="text-secondary small">{{ 'prowlarr.system.info_appdata'|trans }}</td><td class="small" style="word-break:break-all;">{{ status.appData ?? '—' }}</td></tr>
                             <tr><td class="text-secondary small">{{ 'prowlarr.system.info_migration'|trans }}</td><td>{{ status.migrationVersion ?? '—' }}</td></tr>
                             <tr><td class="text-secondary small">{{ 'prowlarr.system.info_authentication'|trans }}</td><td>{{ status.authentication ?? '—' }}</td></tr>

--- a/symfony/templates/prowlarr/tasks.html.twig
+++ b/symfony/templates/prowlarr/tasks.html.twig
@@ -79,7 +79,7 @@
                             </td>
                             <td class="text-muted small">
                                 {% if task.lastExecution is defined %}
-                                    {{ task.lastExecution|date('d/m/Y H:i') }}
+                                    {{ task.lastExecution|prismarr_datetime }}
                                 {% else %}
                                     <span class="text-secondary">{{ 'prowlarr.tasks.last_never'|trans }}</span>
                                 {% endif %}
@@ -93,7 +93,7 @@
                             </td>
                             <td class="text-muted small">
                                 {% if task.nextExecution is defined %}
-                                    {{ task.nextExecution|date('d/m/Y H:i') }}
+                                    {{ task.nextExecution|prismarr_datetime }}
                                 {% else %}
                                     —
                                 {% endif %}

--- a/symfony/templates/prowlarr/updates.html.twig
+++ b/symfony/templates/prowlarr/updates.html.twig
@@ -105,7 +105,7 @@
                             </td>
                             <td class="text-muted small">
                                 {% if update.releaseDate is defined %}
-                                    {{ update.releaseDate|date('d/m/Y') }}
+                                    {{ update.releaseDate|prismarr_date }}
                                 {% else %}
                                     —
                                 {% endif %}

--- a/symfony/templates/qbittorrent/index.html.twig
+++ b/symfony/templates/qbittorrent/index.html.twig
@@ -837,7 +837,7 @@ body[data-bs-theme="dark"] .qbt-torrent-list[data-view="table"] .qbt-cell-progre
             <span class="item" title="{{ 'qbittorrent.row.title_ratio'|trans }}">{{ ico.icon('scale', '', 14) }} {{ (t.ratio ?? 0)|number_format(2) }}</span>
             {% if t.added_on %}
             <span class="sep"></span>
-            <span class="item" title="{{ 'qbittorrent.row.title_added_tpl'|trans|replace({'__DATE__': t.added_on|date('d/m/Y H:i')}) }}">{{ ico.icon('calendar', '', 14) }} {{ t.added_on|date('d/m/y') }}</span>
+            <span class="item" title="{{ 'qbittorrent.row.title_added_tpl'|trans|replace({'__DATE__': t.added_on|prismarr_datetime}) }}">{{ ico.icon('calendar', '', 14) }} {{ t.added_on|prismarr_date }}</span>
             {% endif %}
         </div>
     </div>
@@ -849,7 +849,7 @@ body[data-bs-theme="dark"] .qbt-torrent-list[data-view="table"] .qbt-cell-progre
     <div class="qbt-table-cell qbt-cell-up">{{ t.upspeed > 0 ? t.upspeed|prismarr_speed : '—' }}</div>
     <div class="qbt-table-cell">{{ t.num_seeds }}</div>
     <div class="qbt-table-cell">{{ (t.ratio ?? 0)|number_format(2) }}</div>
-    <div class="qbt-table-cell qbt-cell-added" data-added="{{ t.added_on ?? 0 }}">{% if t.added_on %}{{ t.added_on|date('d/m/y') }}{% else %}—{% endif %}</div>
+    <div class="qbt-table-cell qbt-cell-added" data-added="{{ t.added_on ?? 0 }}">{% if t.added_on %}{{ t.added_on|prismarr_date }}{% else %}—{% endif %}</div>
 
     {# Cellule mode compact — % seul #}
     <div class="qbt-compact-pct">{{ t.progress }}%</div>

--- a/symfony/templates/qbittorrent/index.html.twig
+++ b/symfony/templates/qbittorrent/index.html.twig
@@ -1064,9 +1064,7 @@ body[data-bs-theme="dark"] .qbt-torrent-list[data-view="table"] .qbt-cell-progre
     }
     function fmtDate(ts) {
         if (!ts || ts < 0) return '-';
-        var d = new Date(ts * 1000);
-        var loc = (LOCALE === 'en') ? 'en-US' : 'fr-FR';
-        return d.toLocaleDateString(loc) + ' ' + d.toLocaleTimeString(loc, {hour:'2-digit',minute:'2-digit'});
+        return window._prismarrFmtDateTime(new Date(ts * 1000));
     }
     function escapeHtml(s) { return String(s == null ? '' : s).replace(/[&<>"']/g, function(c){ return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]; }); }
 

--- a/symfony/templates/qbittorrent/index.html.twig
+++ b/symfony/templates/qbittorrent/index.html.twig
@@ -1489,14 +1489,11 @@ body[data-bs-theme="dark"] .qbt-torrent-list[data-view="table"] .qbt-cell-progre
     }
     function fmtShortDate(ts) {
         if (!ts) return '—';
-        var d = new Date(ts * 1000);
-        return ('0' + d.getDate()).slice(-2) + '/' + ('0' + (d.getMonth() + 1)).slice(-2) + '/' + String(d.getFullYear()).slice(-2);
+        return window._prismarrFmtDate(new Date(ts * 1000));
     }
     function fmtLongDate(ts) {
         if (!ts) return '—';
-        var d = new Date(ts * 1000);
-        return ('0' + d.getDate()).slice(-2) + '/' + ('0' + (d.getMonth() + 1)).slice(-2) + '/' + d.getFullYear()
-            + ' ' + ('0' + d.getHours()).slice(-2) + ':' + ('0' + d.getMinutes()).slice(-2);
+        return window._prismarrFmtDateTime(new Date(ts * 1000));
     }
 
     function buildStatsLine(t) {

--- a/symfony/templates/qbittorrent/index.html.twig
+++ b/symfony/templates/qbittorrent/index.html.twig
@@ -870,7 +870,6 @@ body[data-bs-theme="dark"] .qbt-torrent-list[data-view="table"] .qbt-cell-progre
 <script>
 (function(){
     var BASE = '{{ path("app_qbittorrent_index") }}';
-    var LOCALE = {{ app.request.locale|default('fr')|json_encode|raw }};
     var currentFilter = 'all';
     var selectedHashes = {};
     var deleteTarget = { hashes: [], mode: 'single' };

--- a/symfony/templates/radarr/backups.html.twig
+++ b/symfony/templates/radarr/backups.html.twig
@@ -75,7 +75,7 @@
                 {{ backup.size is defined ? backup.size|prismarr_bytes : '—' }}
               </td>
               <td class="text-muted small">
-                {{ backup.time is defined ? backup.time|date('d/m/Y H:i') : '—' }}
+                {{ backup.time is defined ? backup.time|prismarr_datetime : '—' }}
               </td>
               <td class="text-end">
                 <button class="btn btn-ghost-primary btn-sm btn-restore"

--- a/symfony/templates/radarr/commands.html.twig
+++ b/symfony/templates/radarr/commands.html.twig
@@ -71,10 +71,10 @@
               {% endif %}
             </td>
             <td class="text-muted small">
-              {{ cmd.started is defined ? cmd.started|date('H:i:ss') : '—' }}
+              {{ cmd.started is defined ? cmd.started|prismarr_time(true) : '—' }}
             </td>
             <td class="text-muted small">
-              {{ cmd.ended is defined ? cmd.ended|date('H:i:ss') : '—' }}
+              {{ cmd.ended is defined ? cmd.ended|prismarr_time(true) : '—' }}
             </td>
             <td class="text-muted small">
               {% if cmd.duration is defined %}

--- a/symfony/templates/radarr/logs.html.twig
+++ b/symfony/templates/radarr/logs.html.twig
@@ -51,7 +51,7 @@
             {% for log in logs %}
             {% set lvl = log.level|default('info')|lower %}
             <tr data-level="{{ lvl }}">
-              <td class="text-muted small">{{ log.time is defined ? log.time|date('d/m H:i:s') : '—' }}</td>
+              <td class="text-muted small">{{ log.time is defined ? log.time|prismarr_datetime(true) : '—' }}</td>
               <td>
                 {% if lvl == 'error' or lvl == 'fatal' %}
                   <span class="badge bg-danger-lt text-danger">{{ lvl }}</span>

--- a/symfony/templates/radarr/tasks.html.twig
+++ b/symfony/templates/radarr/tasks.html.twig
@@ -26,8 +26,8 @@
             <tr>
               <td class="fw-medium">{{ task.name ?? task.taskName ?? '—' }}</td>
               <td class="text-muted">{{ task.interval is defined ? task.interval ~ ' min' : '—' }}</td>
-              <td class="text-muted small">{{ task.lastExecution is defined ? task.lastExecution|date('d/m/Y H:i') : '—' }}</td>
-              <td class="text-muted small">{{ task.nextExecution is defined ? task.nextExecution|date('d/m/Y H:i') : '—' }}</td>
+              <td class="text-muted small">{{ task.lastExecution is defined ? task.lastExecution|prismarr_datetime : '—' }}</td>
+              <td class="text-muted small">{{ task.nextExecution is defined ? task.nextExecution|prismarr_datetime : '—' }}</td>
               <td>
                 <button class="btn btn-ghost-primary btn-icon btn-sm btn-task-run"
                         data-command="{{ task.taskName ?? task.name ?? '' }}"

--- a/symfony/templates/radarr/updates.html.twig
+++ b/symfony/templates/radarr/updates.html.twig
@@ -64,7 +64,7 @@
                             {{ update.version ?? '—' }}
                             {% if update.latest ?? false %}<span class="badge bg-purple-lt ms-1" style="font-size:.65rem;">{{ 'media.arr_admin.updates.latest'|trans }}</span>{% endif %}
                         </td>
-                        <td class="text-muted small">{{ update.releaseDate is defined ? update.releaseDate|date('d/m/Y') : '—' }}</td>
+                        <td class="text-muted small">{{ update.releaseDate is defined ? update.releaseDate|prismarr_date : '—' }}</td>
                         <td><span class="badge bg-secondary-lt">{{ update.branch ?? '—' }}</span></td>
                         <td>
                             {% if update.installed ?? false %}<span class="badge bg-success-lt text-success">{{ 'media.arr_admin.updates.installed'|trans }}</span>

--- a/symfony/templates/sonarr/backups.html.twig
+++ b/symfony/templates/sonarr/backups.html.twig
@@ -75,7 +75,7 @@
                 {{ backup.size is defined ? backup.size|prismarr_bytes : '—' }}
               </td>
               <td class="text-muted small">
-                {{ backup.time is defined ? backup.time|date('d/m/Y H:i') : '—' }}
+                {{ backup.time is defined ? backup.time|prismarr_datetime : '—' }}
               </td>
               <td class="text-end">
                 <button class="btn btn-ghost-primary btn-sm btn-restore"

--- a/symfony/templates/sonarr/commands.html.twig
+++ b/symfony/templates/sonarr/commands.html.twig
@@ -71,10 +71,10 @@
               {% endif %}
             </td>
             <td class="text-muted small">
-              {{ cmd.started is defined ? cmd.started|date('H:i:ss') : '—' }}
+              {{ cmd.started is defined ? cmd.started|prismarr_time(true) : '—' }}
             </td>
             <td class="text-muted small">
-              {{ cmd.ended is defined ? cmd.ended|date('H:i:ss') : '—' }}
+              {{ cmd.ended is defined ? cmd.ended|prismarr_time(true) : '—' }}
             </td>
             <td class="text-muted small">
               {% if cmd.duration is defined %}

--- a/symfony/templates/sonarr/logs.html.twig
+++ b/symfony/templates/sonarr/logs.html.twig
@@ -51,7 +51,7 @@
             {% for log in logs %}
             {% set lvl = log.level|default('info')|lower %}
             <tr data-level="{{ lvl }}">
-              <td class="text-muted small">{{ log.time is defined ? log.time|date('d/m H:i:s') : '—' }}</td>
+              <td class="text-muted small">{{ log.time is defined ? log.time|prismarr_datetime(true) : '—' }}</td>
               <td>
                 {% if lvl == 'error' or lvl == 'fatal' %}
                   <span class="badge bg-danger-lt text-danger">{{ lvl }}</span>

--- a/symfony/templates/sonarr/tasks.html.twig
+++ b/symfony/templates/sonarr/tasks.html.twig
@@ -26,8 +26,8 @@
             <tr>
               <td class="fw-medium">{{ task.name ?? task.taskName ?? '—' }}</td>
               <td class="text-muted">{{ task.interval is defined ? task.interval ~ ' min' : '—' }}</td>
-              <td class="text-muted small">{{ task.lastExecution is defined ? task.lastExecution|date('d/m/Y H:i') : '—' }}</td>
-              <td class="text-muted small">{{ task.nextExecution is defined ? task.nextExecution|date('d/m/Y H:i') : '—' }}</td>
+              <td class="text-muted small">{{ task.lastExecution is defined ? task.lastExecution|prismarr_datetime : '—' }}</td>
+              <td class="text-muted small">{{ task.nextExecution is defined ? task.nextExecution|prismarr_datetime : '—' }}</td>
               <td>
                 <button class="btn btn-ghost-primary btn-icon btn-sm btn-task-run"
                         data-command="{{ task.taskName ?? task.name ?? '' }}"

--- a/symfony/templates/sonarr/updates.html.twig
+++ b/symfony/templates/sonarr/updates.html.twig
@@ -64,7 +64,7 @@
                             {{ update.version ?? '—' }}
                             {% if update.latest ?? false %}<span class="badge bg-purple-lt ms-1" style="font-size:.65rem;">{{ 'media.arr_admin.updates.latest'|trans }}</span>{% endif %}
                         </td>
-                        <td class="text-muted small">{{ update.releaseDate is defined ? update.releaseDate|date('d/m/Y') : '—' }}</td>
+                        <td class="text-muted small">{{ update.releaseDate is defined ? update.releaseDate|prismarr_date : '—' }}</td>
                         <td><span class="badge bg-secondary-lt">{{ update.branch ?? '—' }}</span></td>
                         <td>
                             {% if update.installed ?? false %}<span class="badge bg-success-lt text-success">{{ 'media.arr_admin.updates.installed'|trans }}</span>

--- a/symfony/templates/transmission/index.html.twig
+++ b/symfony/templates/transmission/index.html.twig
@@ -1379,14 +1379,11 @@ body[data-bs-theme="dark"] .trs-torrent-list[data-view="table"] .trs-cell-progre
     }
     function fmtShortDate(ts) {
         if (!ts) return '—';
-        var d = new Date(ts * 1000);
-        return ('0' + d.getDate()).slice(-2) + '/' + ('0' + (d.getMonth() + 1)).slice(-2) + '/' + String(d.getFullYear()).slice(-2);
+        return window._prismarrFmtDate(new Date(ts * 1000));
     }
     function fmtLongDate(ts) {
         if (!ts) return '—';
-        var d = new Date(ts * 1000);
-        return ('0' + d.getDate()).slice(-2) + '/' + ('0' + (d.getMonth() + 1)).slice(-2) + '/' + d.getFullYear()
-            + ' ' + ('0' + d.getHours()).slice(-2) + ':' + ('0' + d.getMinutes()).slice(-2);
+        return window._prismarrFmtDateTime(new Date(ts * 1000));
     }
 
     function buildStatsLine(t) {

--- a/symfony/templates/transmission/index.html.twig
+++ b/symfony/templates/transmission/index.html.twig
@@ -778,7 +778,7 @@ body[data-bs-theme="dark"] .trs-torrent-list[data-view="table"] .trs-cell-progre
             <span class="item" title="{{ 'transmission.row.title_ratio'|trans }}">{{ ico.icon('scale', '', 14) }} {{ (t.ratio ?? 0)|number_format(2) }}</span>
             {% if t.added_on %}
             <span class="sep"></span>
-            <span class="item" title="{{ 'transmission.row.title_added_tpl'|trans|replace({'__DATE__': t.added_on|date('d/m/Y H:i')}) }}">{{ ico.icon('calendar', '', 14) }} {{ t.added_on|date('d/m/y') }}</span>
+            <span class="item" title="{{ 'transmission.row.title_added_tpl'|trans|replace({'__DATE__': t.added_on|prismarr_datetime}) }}">{{ ico.icon('calendar', '', 14) }} {{ t.added_on|prismarr_date }}</span>
             {% endif %}
         </div>
     </div>
@@ -790,7 +790,7 @@ body[data-bs-theme="dark"] .trs-torrent-list[data-view="table"] .trs-cell-progre
     <div class="trs-table-cell trs-cell-up">{{ t.upspeed > 0 ? t.upspeed|prismarr_speed : '—' }}</div>
     <div class="trs-table-cell">{{ t.num_seeds }}</div>
     <div class="trs-table-cell">{{ (t.ratio ?? 0)|number_format(2) }}</div>
-    <div class="trs-table-cell trs-cell-added" data-added="{{ t.added_on ?? 0 }}">{% if t.added_on %}{{ t.added_on|date('d/m/y') }}{% else %}—{% endif %}</div>
+    <div class="trs-table-cell trs-cell-added" data-added="{{ t.added_on ?? 0 }}">{% if t.added_on %}{{ t.added_on|prismarr_date }}{% else %}—{% endif %}</div>
 
     {# Cellule mode compact — % seul #}
     <div class="trs-compact-pct">{{ t.progress }}%</div>

--- a/symfony/templates/transmission/index.html.twig
+++ b/symfony/templates/transmission/index.html.twig
@@ -995,9 +995,7 @@ body[data-bs-theme="dark"] .trs-torrent-list[data-view="table"] .trs-cell-progre
     }
     function fmtDate(ts) {
         if (!ts || ts < 0) return '-';
-        var d = new Date(ts * 1000);
-        var loc = (LOCALE === 'en') ? 'en-US' : 'fr-FR';
-        return d.toLocaleDateString(loc) + ' ' + d.toLocaleTimeString(loc, {hour:'2-digit',minute:'2-digit'});
+        return window._prismarrFmtDateTime(new Date(ts * 1000));
     }
     function escapeHtml(s) { return String(s == null ? '' : s).replace(/[&<>"']/g, function(c){ return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]; }); }
 

--- a/symfony/templates/transmission/index.html.twig
+++ b/symfony/templates/transmission/index.html.twig
@@ -811,7 +811,6 @@ body[data-bs-theme="dark"] .trs-torrent-list[data-view="table"] .trs-cell-progre
 <script>
 (function(){
     var BASE = '{{ path("app_transmission_index") }}';
-    var LOCALE = {{ app.request.locale|default('fr')|json_encode|raw }};
     var currentFilter = 'all';
     var selectedHashes = {};
     var deleteTarget = { hashes: [], mode: 'single' };

--- a/symfony/tests/Service/DisplayPreferencesServiceTest.php
+++ b/symfony/tests/Service/DisplayPreferencesServiceTest.php
@@ -185,6 +185,37 @@ class DisplayPreferencesServiceTest extends TestCase
         $this->assertSame('2026-04-21 · 14:30', $prefs->formatDateTime($dt));
     }
 
+    public function testFormatTimeWithSecondsHonorsPreference(): void
+    {
+        // Log / command tables need second precision; the flag is opt-in so
+        // every existing caller keeps its seconds-free output.
+        $dt = new \DateTimeImmutable('2026-04-21 14:30:07', new \DateTimeZone('Europe/Paris'));
+        $paris = ['display_timezone' => 'Europe/Paris'];
+
+        $this->assertSame('14:30:07', $this->serviceWith($paris + ['display_time_format' => '24h'])->formatTime($dt, true));
+        $this->assertSame('2:30:07 PM', $this->serviceWith($paris + ['display_time_format' => '12h'])->formatTime($dt, true));
+
+        // Omitting the flag must be unchanged behaviour.
+        $this->assertSame('14:30', $this->serviceWith($paris + ['display_time_format' => '24h'])->formatTime($dt));
+        $this->assertSame('2:30 PM', $this->serviceWith($paris + ['display_time_format' => '12h'])->formatTime($dt));
+
+        $this->assertNull($this->serviceWith([])->formatTime(null, true));
+    }
+
+    public function testFormatDateTimeWithSecondsForwardsTheFlag(): void
+    {
+        $dt = new \DateTimeImmutable('2026-04-21 14:30:07', new \DateTimeZone('Europe/Paris'));
+        $prefs = $this->serviceWith([
+            'display_date_format' => 'iso',
+            'display_time_format' => '24h',
+            'display_timezone'    => 'Europe/Paris',
+        ]);
+
+        $this->assertSame('2026-04-21 · 14:30:07', $prefs->formatDateTime($dt, true));
+        $this->assertSame('2026-04-21 · 14:30', $prefs->formatDateTime($dt));
+        $this->assertNull($prefs->formatDateTime(null, true));
+    }
+
     public function testInvalidStoredTimezoneFallsBackToRawDatetime(): void
     {
         // An invalid timezone in the DB must not crash the render.


### PR DESCRIPTION
Fixes #54.

The Display settings already offer date format (French / American / ISO), time format (24h/12h) and timezone, and the `prismarr_date` / `prismarr_time` / `prismarr_datetime` filters already implement them — but ~40 template call sites still rendered hardcoded European `d/m/Y` formats, three of them with a hardcoded `Europe/Paris` timezone, and the client-side formatters ignored the preference entirely. This PR closes the gap:

- **Server sweep:** every user-facing `|date('d/m…')`-family call (34 templates) now uses the preference-aware filters; the three `Europe/Paris` args are gone (the series air-date keeps its weekday via `display_pref('timezone')`). `formatTime`/`formatDateTime` gain an opt-in `withSeconds` flag so log/system pages keep their seconds (this also fixes a pre-existing `H:i:ss` double-seconds typo). Internal uses (`Y-m-d` bucketing keys, `data-*` ISO attrs, copyright years) are deliberately untouched.
- **Client sweep:** `base.html.twig` exposes the prefs (`window._prismarrDatePrefs`) plus three tiny formatters that mirror the Twig filters exactly (same `us`/`iso` output, same `·` separator, same no-leading-zero 12h, invalid dates → `—`), defined in the head block because some pages format dates during initial parse. The page-local formatters on the qBittorrent/Deluge/Transmission/Prowlarr/Jellyseerr/films pages — several of which hardcoded `fr-FR` — now delegate to them, so poller-rebuilt rows match the server-rendered ones. The prefs re-stamp on every document, so a settings change takes effect without a hard reload. A final chore commit drops the `var LOCALE` locals this orphaned.

Two deliberate behavior notes:
- Null dates previously rendered as *today* (Twig's `|date(null)` behavior); they now render empty — truthful rather than fabricated.
- Date-only payloads (e.g. release dates) are now converted into the display timezone, so they can legitimately shift a day for users whose display timezone differs from the server's — same behavior as Radarr's own UI.

Known follow-up (left out as non-mechanical): the calendar page hand-builds `dd/mm/yyyy` in JS.

Tests: seconds-flag unit tests (`DisplayPreferencesServiceTest`, 16/16), `lint:twig` across all 159 templates, smoke suite green — full suite on this branch: 779/779. Verified live: torrent Added columns, tooltips, log pages and the settings round-trip all follow the preference, in all three date formats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)