### PR TITLE
perf: serve the Radarr/Sonarr library stale-while-revalidate from one shared cache entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Prismarr are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Performance
+- **The Radarr/Sonarr library is served stale-while-revalidate, from one shared entry.** The 45 s `MediaLibraryCache` window still expired inside a request, so whoever arrived first after it lapsed paid the full multi-second `getMovies()` / `getSeries()` fetch before anything rendered — and the dashboard kept its own second copy of the same payload (`dash.movies` / `dash.series`) with no invalidation hook, so a change made on the Films page could stay invisible on the dashboard for the rest of the window. A new shared `StaleWhileRevalidateCache` splits the window in two: 45 s is now the *soft* TTL (a lapsed entry is served immediately and a rebuild is queued to the already-running `messenger-worker` service, so the refetch happens outside the request) and 600 s is the hard ceiling past which a read still blocks, because the library pages cannot render without the list. The dashboard now reads the same per-instance entry as the library pages, so the three duplicate fetch paths collapse into one and existing library invalidations finally reach the dashboard. Measured on a large library: the Films page's cold load drops from ~11.5 s to ~0.32 s and the dashboard's recent-additions fragment from ~3.8 s to ~0.25 s. An empty or failed fetch is still never cached, a mutation still invalidates hard (the next read refetches), a refresh is skipped for an instance whose circuit breaker is open, and a rebuild that goes unanswered for 180 s logs one rate-limited error — the visible symptom of a stopped worker.
+
 ## [1.2.0] - 2026-08-29
 
 ### Fixed

--- a/docker/frankenphp/s6/messenger-worker/run
+++ b/docker/frankenphp/s6/messenger-worker/run
@@ -1,4 +1,10 @@
 #!/command/with-contenv sh
 sleep 3
 # Drop privileges: the messenger worker runs as www-data (UID 82).
-exec s6-setuidgid www-data php /var/www/html/bin/console messenger:consume async --time-limit=3600 --memory-limit=256M -v
+# 512M, not 256M: one library refresh decodes a whole Radarr/Sonarr payload
+# (thousands of rows, ~120-180 MB peak on a large library). At 256M the
+# consumer would recycle after nearly every refresh; php.ini's own
+# memory_limit (1024M) is the real ceiling — unless an
+# operator sets PHP_MEMORY_LIMIT (see init.sh), which can push php.ini's own
+# limit below this consumer's 512M and make it the effective ceiling instead.
+exec s6-setuidgid www-data php /var/www/html/bin/console messenger:consume async --time-limit=3600 --memory-limit=512M -v

--- a/symfony/config/packages/messenger.yaml
+++ b/symfony/config/packages/messenger.yaml
@@ -13,6 +13,7 @@ framework:
             failed: 'doctrine://default?queue_name=failed'
             sync: 'sync://'
 
-        # No active async routing for now — future Prismarr messages
-        # (notifications, scheduled tasks) will be added here.
-        routing: {}
+        # Cache refreshes run in the messenger-worker s6 service so a slow
+        # upstream fetch never occupies a FrankenPHP web worker.
+        routing:
+            App\Message\RefreshCacheKey: async

--- a/symfony/config/packages/test/messenger.yaml
+++ b/symfony/config/packages/test/messenger.yaml
@@ -1,0 +1,8 @@
+# Test env only. The messenger_messages table is NOT in the ORM schema that
+# AbstractWebTestCase::resetSchema() builds, so a doctrine-transport dispatch
+# would run auto_setup DDL inside every functional test. in-memory:// keeps
+# dispatches assertable (->getSent()) and touches no database.
+framework:
+    messenger:
+        transports:
+            async: 'in-memory://'

--- a/symfony/src/Controller/DashboardController.php
+++ b/symfony/src/Controller/DashboardController.php
@@ -6,6 +6,7 @@ use App\Entity\ServiceInstance;
 use App\Repository\Media\WatchlistItemRepository;
 use App\Service\HealthService;
 use App\Service\Media\JellyseerrClient;
+use App\Service\Media\MediaLibraryCache;
 use App\Service\Media\RadarrClient;
 use App\Service\Media\SonarrClient;
 use App\Service\Media\TautulliClient;
@@ -64,6 +65,12 @@ class DashboardController extends AbstractController
         private readonly CacheInterface $cache,
         private readonly TautulliClient $tautulli,
         private readonly \App\Service\DashboardLayoutService $layout,
+        // Shared per-instance library cache: replaces this controller's
+        // private dash.movies/dash.series copies so the dashboard shares one
+        // entry with the Films/Series pages — and so MediaController's
+        // invalidation sites finally reach the dashboard. Nullable + last so
+        // legacy positional test constructors keep working.
+        private readonly ?MediaLibraryCache $libraryCache = null,
     ) {}
 
     /**
@@ -107,40 +114,59 @@ class DashboardController extends AbstractController
      */
     private function movies(): array
     {
-        return $this->moviesCache ??= $this->cached('movies', function () {
-            $out = [];
-            foreach ($this->instances->getEnabled(ServiceInstance::TYPE_RADARR) as $inst) {
-                $rows = $this->safeFetch(
-                    'library.movies.' . $inst->getSlug(),
-                    fn() => $this->radarr->withInstance($inst)->getMovies(),
-                ) ?? [];
-                foreach ($rows as $row) {
-                    $row['_instanceSlug'] = $inst->getSlug();
-                    $row['_instanceName'] = $inst->getName();
-                    $out[] = $row;
-                }
-            }
-            return $out;
-        });
+        return $this->moviesCache ??= $this->collectLibrary(ServiceInstance::TYPE_RADARR);
     }
 
     private function series(): array
     {
-        return $this->seriesCache ??= $this->cached('series', function () {
-            $out = [];
-            foreach ($this->instances->getEnabled(ServiceInstance::TYPE_SONARR) as $inst) {
-                $rows = $this->safeFetch(
-                    'library.series.' . $inst->getSlug(),
-                    fn() => $this->sonarr->withInstance($inst)->getSeries(),
-                ) ?? [];
-                foreach ($rows as $row) {
-                    $row['_instanceSlug'] = $inst->getSlug();
-                    $row['_instanceName'] = $inst->getName();
-                    $out[] = $row;
-                }
+        return $this->seriesCache ??= $this->collectLibrary(ServiceInstance::TYPE_SONARR);
+    }
+
+    /**
+     * Fan out over every enabled instance, reading each one's list through the
+     * SHARED MediaLibraryCache entry (`media.movies.<slug>` /
+     * `media.series.<slug>`) rather than this controller's own
+     * `dash.movies` / `dash.series` copy, then tag the rows with the instance
+     * they came from. The tag is applied HERE, never stored in the cache —
+     * MediaController's library pages read the same entry and must not see
+     * dashboard-private keys.
+     *
+     * `dash.movies` / `dash.series` were a second, uncoordinated 45 s copy of
+     * the same payload with no invalidation hook, so a mutation on the Films
+     * page could stay invisible on the dashboard for the rest of the window.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function collectLibrary(string $type): array
+    {
+        $isMovies = $type === ServiceInstance::TYPE_RADARR;
+        $out      = [];
+
+        foreach ($this->instances->getEnabled($type) as $inst) {
+            $slug = $inst->getSlug();
+            $rows = $this->safeFetch(
+                'library.' . ($isMovies ? 'movies.' : 'series.') . $slug,
+                function () use ($isMovies, $inst, $slug) {
+                    if ($this->libraryCache === null) {
+                        return $isMovies
+                            ? $this->radarr->withInstance($inst)->getMovies()
+                            : $this->sonarr->withInstance($inst)->getSeries();
+                    }
+
+                    return $isMovies
+                        ? $this->libraryCache->movies($slug, fn() => $this->radarr->withInstance($inst)->getMovies())
+                        : $this->libraryCache->series($slug, fn() => $this->sonarr->withInstance($inst)->getSeries());
+                },
+            ) ?? [];
+
+            foreach ($rows as $row) {
+                $row['_instanceSlug'] = $slug;
+                $row['_instanceName'] = $inst->getName();
+                $out[] = $row;
             }
-            return $out;
-        });
+        }
+
+        return $out;
     }
 
     #[Route('/tableau-de-bord', name: 'app_dashboard')]

--- a/symfony/src/Message/RefreshCacheKey.php
+++ b/symfony/src/Message/RefreshCacheKey.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Message;
+
+/**
+ * "Please refresh the cache entry under this key, off the request path."
+ *
+ * The key is always constructed by the application (a class constant or a
+ * constant prefix + an instance slug) — never taken from user input.
+ */
+final readonly class RefreshCacheKey
+{
+    public function __construct(public string $key) {}
+}

--- a/symfony/src/MessageHandler/RefreshCacheKeyHandler.php
+++ b/symfony/src/MessageHandler/RefreshCacheKeyHandler.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Message\RefreshCacheKey;
+use App\Service\Cache\CacheRefresherInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Routes a RefreshCacheKey to every CacheRefresherInterface whose supports()
+ * claims the key.
+ *
+ * This deliberately does NOT stop at the first match. The tagged iterator's
+ * order is container registration order, which is not a stable API — a
+ * "first match wins" handler would let one refresher's supports() prefix
+ * silently shadow another's (e.g. a hypothetical "media." refresher
+ * swallowing every key meant for a "media.movies." refresher) depending on
+ * registration order alone. CacheRefresherInterface instead requires
+ * supports() domains to be mutually exclusive; calling every match and
+ * warning when more than one fires makes an accidental overlap visible
+ * instead of silently picking a winner.
+ */
+#[AsMessageHandler]
+final class RefreshCacheKeyHandler
+{
+    /** @param iterable<CacheRefresherInterface> $refreshers */
+    public function __construct(
+        #[AutowireIterator('app.cache_refresher')]
+        private readonly iterable $refreshers,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function __invoke(RefreshCacheKey $message): void
+    {
+        $matches = 0;
+        foreach ($this->refreshers as $refresher) {
+            if ($refresher->supports($message->key)) {
+                ++$matches;
+                $refresher->refresh($message->key);
+            }
+        }
+
+        if ($matches === 0) {
+            // Deliberately NOT thrown: a throw costs three retries and then a
+            // row in the `failed` transport nobody monitors. A warning is the
+            // right amount of noise for a key whose owner was removed.
+            $this->logger->warning('RefreshCacheKey: no refresher claims this key', ['key' => $message->key]);
+
+            return;
+        }
+
+        if ($matches > 1) {
+            // supports() domains are supposed to be mutually exclusive
+            // (CacheRefresherInterface); more than one match means two
+            // refreshers' domains collide. Still ack — both already ran and
+            // refreshers are required to be idempotent — but this should
+            // never happen in a correctly configured app, so it is worth
+            // surfacing rather than silently tolerating.
+            $this->logger->warning('RefreshCacheKey: multiple refreshers claim this key', [
+                'key'   => $message->key,
+                'count' => $matches,
+            ]);
+        }
+    }
+}

--- a/symfony/src/Service/Cache/CacheRefresherInterface.php
+++ b/symfony/src/Service/Cache/CacheRefresherInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Service\Cache;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+/**
+ * Owns the "how do I rebuild this cache entry" half of the SWR contract.
+ * Implementations are collected by RefreshCacheKeyHandler through the
+ * app.cache_refresher tag; EVERY refresher whose supports() answers true for
+ * a key is called (see the handler's docblock for why "first match wins"
+ * was rejected).
+ *
+ * Implementer obligations:
+ *  - supports() domains MUST be mutually exclusive across all refreshers.
+ *    Tagged-iterator order is container registration order, not a stable
+ *    API, so relying on prefix shadowing (one refresher's prefix being a
+ *    superset of another's) is not safe at any ordering. The handler logs a
+ *    warning if two refreshers ever claim the same key, but that is a safety
+ *    net for a misconfiguration, not something to design around.
+ *  - Before doing any refresh work, check ServiceHealthCache::isDown() for
+ *    the service you own and return immediately if it is down: never hammer
+ *    a service its own circuit breaker just marked down.
+ *  - Never persist (e.g. via StaleWhileRevalidateCache::write()) on a
+ *    failed/empty fetch — leave the previous good value untouched.
+ *  - Be idempotent: re-read the current cache state first and return early
+ *    if it is already fresh. A duplicate message can arrive from at-least-
+ *    once transport delivery, and — see above — from an accidental
+ *    supports() overlap.
+ */
+#[AutoconfigureTag('app.cache_refresher')]
+interface CacheRefresherInterface
+{
+    public function supports(string $key): bool;
+
+    /** Must be idempotent: a duplicate message may arrive. */
+    public function refresh(string $key): void;
+}

--- a/symfony/src/Service/Cache/MediaLibraryRefresher.php
+++ b/symfony/src/Service/Cache/MediaLibraryRefresher.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Service\Cache;
+
+use App\Entity\ServiceInstance;
+use App\Service\Media\MediaLibraryCache;
+use App\Service\Media\RadarrClient;
+use App\Service\Media\ServiceHealthCache;
+use App\Service\Media\SonarrClient;
+use App\Service\ServiceInstanceProvider;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Rebuilds `media.movies.<slug>` / `media.series.<slug>` inside the
+ * messenger-worker process, so the multi-second full-library fetch never
+ * occupies a FrankenPHP web worker.
+ *
+ * The entry is shared by the library pages and the dashboard, so whichever
+ * code path refills it decides what all of them see.
+ */
+final class MediaLibraryRefresher implements CacheRefresherInterface
+{
+    private const PREFIX_MOVIES = 'media.movies.';
+    private const PREFIX_SERIES = 'media.series.';
+
+    public function __construct(
+        private readonly ServiceInstanceProvider $instances,
+        private readonly RadarrClient $radarr,
+        private readonly SonarrClient $sonarr,
+        private readonly StaleWhileRevalidateCache $swr,
+        private readonly ServiceHealthCache $health,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function supports(string $key): bool
+    {
+        return str_starts_with($key, self::PREFIX_MOVIES) || str_starts_with($key, self::PREFIX_SERIES);
+    }
+
+    public function refresh(string $key): void
+    {
+        $isMovies = str_starts_with($key, self::PREFIX_MOVIES);
+        $slug     = substr($key, strlen($isMovies ? self::PREFIX_MOVIES : self::PREFIX_SERIES));
+        if ($slug === '') {
+            return;
+        }
+
+        // Idempotence: a duplicate message costs one cache read and stops here.
+        $hit = $this->swr->read($key, MediaLibraryCache::TTL);
+        if ($hit !== null && $hit['state'] === 'fresh') {
+            return;
+        }
+
+        $type     = $isMovies ? ServiceInstance::TYPE_RADARR : ServiceInstance::TYPE_SONARR;
+        $service  = $isMovies ? 'radarr' : 'sonarr';
+        $instance = $this->instances->getBySlug($type, $slug);
+        if ($instance === null || !$instance->isEnabled()) {
+            return;
+        }
+
+        // Never hammer a service its own circuit breaker just marked down.
+        // radarr/sonarr mark the breaker WITH the instance slug, so this
+        // check is per instance, exactly like the clients' own.
+        if ($this->health->isDown($service, $slug)) {
+            return;
+        }
+
+        try {
+            $rows = $isMovies
+                ? $this->radarr->withInstance($instance)->getMovies()
+                : $this->sonarr->withInstance($instance)->getSeries();
+        } catch (\Throwable $e) {
+            $this->logger->warning('Library refresh failed', [
+                'key' => $key, 'exception' => $e::class, 'message' => $e->getMessage(),
+            ]);
+
+            return;
+        }
+
+        // An empty list is a failed fetch — leave the previous good value alone.
+        if ($rows === []) {
+            return;
+        }
+
+        $this->swr->write($key, $rows, MediaLibraryCache::HARD_TTL);
+    }
+}

--- a/symfony/src/Service/Cache/StaleWhileRevalidateCache.php
+++ b/symfony/src/Service/Cache/StaleWhileRevalidateCache.php
@@ -166,7 +166,13 @@ final class StaleWhileRevalidateCache
             // must not create a live entry: writing it anyway (even with a
             // clamped near-zero TTL) risks the pool briefly serving an
             // envelope that is already past its own hard life, breaking
-            // "hard miss == pool miss".
+            // "hard miss == pool miss". The demand this write would have
+            // answered is moot for the same reason — the data it carries is
+            // already too old to serve — so drop the requested-at stamp too;
+            // otherwise it lingers and can trip refreshIsOverdue() for a
+            // request nothing will ever answer.
+            $this->cacheApp->deleteItem($key . '.requested_at');
+
             return;
         }
 
@@ -188,6 +194,18 @@ final class StaleWhileRevalidateCache
     public function delete(string $key): void
     {
         $this->cacheApp->deleteItems([$key, $key . '.refreshing', $key . '.requested_at']);
+    }
+
+    /**
+     * Exposes the underlying pool so a caller can co-locate its OWN small
+     * throttle markers (e.g. MediaLibraryCache's overdue-log marker) next to
+     * the ones this class already keeps, without wiring a second
+     * CacheItemPoolInterface dependency through everything that already holds
+     * a StaleWhileRevalidateCache.
+     */
+    public function getPool(): CacheItemPoolInterface
+    {
+        return $this->cacheApp;
     }
 
     /**

--- a/symfony/src/Service/Cache/StaleWhileRevalidateCache.php
+++ b/symfony/src/Service/Cache/StaleWhileRevalidateCache.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace App\Service\Cache;
+
+use App\Message\RefreshCacheKey;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+/**
+ * The one stale-while-revalidate primitive shared by every cached dataset.
+ * Values live in cache.app (filesystem, atomic tmp+rename writes) as
+ * {fetchedAt, value} envelopes with expiresAfter(hardTtl), so a hard miss ==
+ * a pool miss.
+ *
+ * Two read paths on purpose:
+ *   read()          — never fetches. For datasets a page can render without
+ *                     (an optional badge, counter or side panel).
+ *                     Structurally safe: any pool failure degrades to "no
+ *                     cached data", never a 500, because this can sit
+ *                     directly on the render path.
+ *   getOrCompute()  — fetches inline on a hard miss, THROUGH the contracts
+ *                     cache so Symfony's LockRegistry flock still gives
+ *                     cross-worker single-flight, and with $beta = 0 so
+ *                     probabilistic early expiration cannot fire a surprise
+ *                     inline refill before the hard TTL. For datasets a page
+ *                     cannot render without (the library lists).
+ *
+ * Refreshes never run in the web process: requestRefresh() sets a short
+ * coalescing marker and dispatches RefreshCacheKey to the `async` transport,
+ * consumed by the already-running messenger-worker s6 service.
+ */
+final class StaleWhileRevalidateCache
+{
+    /** Seconds a coalescing marker suppresses further dispatches for one key. */
+    public const MARKER_TTL = 30;
+
+    /** Seconds an unanswered refresh request is remembered (dead-consumer probe). */
+    public const REQUEST_TTL = 900;
+
+    public function __construct(
+        private readonly CacheInterface $cache,
+        private readonly CacheItemPoolInterface $cacheApp,
+        private readonly MessageBusInterface $bus,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /** @return array{value: mixed, state: 'fresh'|'stale'}|null null = hard miss */
+    public function read(string $key, int $softTtl): ?array
+    {
+        try {
+            $item = $this->cacheApp->getItem($key);
+            if (!$item->isHit()) {
+                return null;
+            }
+
+            $env = $item->get();
+            if (!is_array($env) || !isset($env['fetchedAt']) || !array_key_exists('value', $env)) {
+                // Shape from an older build (or a corrupt entry): treat as a
+                // miss and drop it so getOrCompute() cannot hand it back.
+                $this->cacheApp->deleteItem($key);
+
+                return null;
+            }
+
+            return [
+                'value' => $env['value'],
+                'state' => (time() - (int) $env['fetchedAt']) < $softTtl ? 'fresh' : 'stale',
+            ];
+        } catch (\Throwable $e) {
+            // This sits directly on the page/badge-render path: a broken
+            // pool adapter or a reserved-character key must degrade to "no
+            // cached data" here, never surface as a 500.
+            $this->logger->warning('SWR read failed', [
+                'key'       => $key,
+                'exception' => $e::class,
+                'message'   => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+
+    /**
+     * @param callable():mixed $fetch
+     * @return array{value: mixed, state: 'fresh'|'stale'}
+     */
+    public function getOrCompute(string $key, int $softTtl, int $hardTtl, callable $fetch): array
+    {
+        $hit = $this->read($key, $softTtl);
+        if ($hit !== null) {
+            return $hit;
+        }
+
+        $env = $this->cache->get(
+            $key,
+            static function (ItemInterface $item) use ($fetch, $hardTtl): array {
+                $value = $fetch();
+                // An empty/failed fetch is never cached as success (never
+                // "effectively permanent" stale data): expiresAfter(0) means
+                // the entry is gone the instant this callback returns, so the
+                // very next read is a hard miss again. Concurrent
+                // LockRegistry waiters queued behind this same key may each
+                // land here and re-run $fetch once the lock is released —
+                // that is exactly pre-SWR behaviour (no caching at all on a
+                // failure), and it is ServiceHealthCache's own circuit
+                // breaker that bounds the resulting call volume once a
+                // service is marked down, not this cache.
+                $item->expiresAfter($value === [] ? 0 : $hardTtl);
+
+                return ['fetchedAt' => time(), 'value' => $value];
+            },
+            0.0, // disable probabilistic early expiration
+        );
+
+        // The callback above only runs on a MISS: a cache hit hands back
+        // whatever was already stored under this key (an older build's
+        // envelope shape, or a stand-in CacheInterface in a test), so the
+        // callback's return type is not a runtime guarantee here.
+        if (!is_array($env) || !isset($env['fetchedAt']) || !array_key_exists('value', $env)) {
+            // Never trust the contracts cache blindly — the return type
+            // above is a hint, not a guarantee. A malformed/foreign-shaped
+            // result is the same corrupt-entry case read() guards against:
+            // treat it as a miss, drop whatever is in the pool under this
+            // key, and recompute directly so the caller still gets an answer.
+            $this->cacheApp->deleteItem($key);
+            $value = $fetch();
+            if ($value !== []) {
+                $this->cacheApp->deleteItem($key . '.requested_at');
+            }
+
+            return ['value' => $value, 'state' => 'fresh'];
+        }
+
+        // A LockRegistry waiter can be released after the entry it was
+        // waiting on has already crossed the soft TTL (e.g. a slow fetch
+        // plus a short soft window): derive state from fetchedAt exactly
+        // like read() does, never hardcode 'fresh'.
+        $fetchedAt = (int) $env['fetchedAt'];
+        if ($env['value'] !== []) {
+            // The demand was answered inline with real data; stop counting
+            // it as overdue — mirrors write(), which by convention (see
+            // MediaLibraryRefresher) is likewise only ever called on a
+            // non-empty fetch. See refreshIsOverdue().
+            $this->cacheApp->deleteItem($key . '.requested_at');
+        }
+
+        return [
+            'value' => $env['value'],
+            'state' => (time() - $fetchedAt) < $softTtl ? 'fresh' : 'stale',
+        ];
+    }
+
+    public function write(string $key, mixed $value, int $hardTtl, ?int $fetchedAt = null): void
+    {
+        if ($hardTtl <= 0) {
+            throw new \InvalidArgumentException(sprintf('StaleWhileRevalidateCache::write(): $hardTtl must be > 0, got %d.', $hardTtl));
+        }
+
+        $fetchedAt = $fetchedAt ?? time();
+        $remaining = $hardTtl - (time() - $fetchedAt);
+        if ($remaining <= 0) {
+            // A back-dated $fetchedAt whose hard window has already elapsed
+            // must not create a live entry: writing it anyway (even with a
+            // clamped near-zero TTL) risks the pool briefly serving an
+            // envelope that is already past its own hard life, breaking
+            // "hard miss == pool miss".
+            return;
+        }
+
+        $item = $this->cacheApp->getItem($key);
+        $item->set(['fetchedAt' => $fetchedAt, 'value' => $value]);
+        // Clamp to what is actually left of the hard window, not the full
+        // $hardTtl, so a back-dated write can never outlive an on-time one.
+        $item->expiresAfter($remaining);
+        $this->cacheApp->save($item);
+
+        // The request was answered; stop counting it as overdue. This never
+        // touches the .refreshing coalescing marker — that marker exists to
+        // suppress duplicate DISPATCHES within its own short window and
+        // expires on its own; a refresh completing early does not change
+        // that.
+        $this->cacheApp->deleteItem($key . '.requested_at');
+    }
+
+    public function delete(string $key): void
+    {
+        $this->cacheApp->deleteItems([$key, $key . '.refreshing', $key . '.requested_at']);
+    }
+
+    /**
+     * Best-effort single flight: PSR-6 has no atomic "add if absent", so the
+     * isHit() check and the save() below are not atomic against a concurrent
+     * caller. A rare duplicate dispatch is bounded — CacheRefresherInterface
+     * requires refreshers to be idempotent — and far cheaper than a
+     * distributed lock would be for a 30 s coalescing window.
+     *
+     * Never throws: the whole body is one try/catch because ANY step here
+     * (getItem/save on either key, or the dispatch itself) can throw — a
+     * PSR-6 reserved-character key, a broken pool, or a dead transport — and
+     * this is called from the main request path, where the page must
+     * degrade (serve the stale/cached value) rather than 500. On failure the
+     * marker is dropped in its OWN nested try/catch so a failing cleanup can
+     * never mask (and replace) the original error in the log below.
+     */
+    public function requestRefresh(string $key): void
+    {
+        try {
+            $marker = $this->cacheApp->getItem($key . '.refreshing');
+            if ($marker->isHit()) {
+                return;
+            }
+
+            $marker->set(true);
+            $marker->expiresAfter(self::MARKER_TTL);
+            $this->cacheApp->save($marker);
+
+            $stamp = $this->cacheApp->getItem($key . '.requested_at');
+            if (!$stamp->isHit()) {
+                $stamp->set(time());
+                $stamp->expiresAfter(self::REQUEST_TTL);
+                $this->cacheApp->save($stamp);
+            }
+
+            $this->bus->dispatch(new RefreshCacheKey($key));
+        } catch (\Throwable $e) {
+            try {
+                $this->cacheApp->deleteItem($key . '.refreshing');
+            } catch (\Throwable) {
+                // Cleanup is itself best-effort: if the pool is broken enough
+                // that even a delete fails, the marker will simply expire on
+                // its own after MARKER_TTL seconds. Swallow so this cannot
+                // replace the original error logged below.
+            }
+
+            // Log only the exception class/message, never the message bus
+            // envelope or transport DSN: a credentialed transport DSN can
+            // appear in stamps/metadata a bus implementation attaches, and
+            // RefreshCacheKey itself carries only the (app-constructed,
+            // never user-supplied) cache key.
+            $this->logger->error('SWR refresh dispatch failed', [
+                'key'       => $key,
+                'exception' => $e::class,
+                'message'   => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * True when a refresh was asked for at least $seconds ago and never
+     * answered. The stamp is cleared by both write() and a successful
+     * (non-empty) getOrCompute() inline compute — either one means the
+     * demand was answered, whether that happened in the background
+     * refresher or inline in a request that hit a hard miss.
+     */
+    public function refreshIsOverdue(string $key, int $seconds): bool
+    {
+        $stamp = $this->cacheApp->getItem($key . '.requested_at');
+        if (!$stamp->isHit()) {
+            return false;
+        }
+
+        return (time() - (int) $stamp->get()) >= $seconds;
+    }
+}

--- a/symfony/src/Service/Media/MediaLibraryCache.php
+++ b/symfony/src/Service/Media/MediaLibraryCache.php
@@ -2,8 +2,7 @@
 
 namespace App\Service\Media;
 
-use Symfony\Contracts\Cache\CacheInterface;
-use Symfony\Contracts\Cache\ItemInterface;
+use App\Service\Cache\StaleWhileRevalidateCache;
 
 /**
  * Short-TTL cache for the heavy Radarr/Sonarr library list.
@@ -17,13 +16,22 @@ use Symfony\Contracts\Cache\ItemInterface;
  * another's. An empty result is NOT cached (expires immediately) so a
  * transient total failure isn't pinned for the whole window — mirrors
  * DashboardController's self-heal.
+ *
+ * This is a thin caller of StaleWhileRevalidateCache: TTL is the SOFT window
+ * (a stale list is served immediately and a background refresh is requested),
+ * HARD_TTL is the ceiling past which a read blocks and refetches inline — the
+ * library pages cannot render without this list, so a hard miss must not be
+ * served empty. An empty result is still never cached.
  */
 class MediaLibraryCache
 {
-    /** @internal Exposed for tests; matches DashboardController::WIDGET_CACHE_TTL. */
+    /** @internal Exposed for tests; matches DashboardController::WIDGET_CACHE_TTL. Soft window. */
     public const TTL = 45; // seconds
 
-    public function __construct(private readonly CacheInterface $cache) {}
+    /** Ceiling: past this a read blocks and refetches inline. Bounded staleness, never permanent. */
+    public const HARD_TTL = 600; // seconds
+
+    public function __construct(private readonly StaleWhileRevalidateCache $swr) {}
 
     /**
      * @param callable():array $fetch
@@ -43,11 +51,11 @@ class MediaLibraryCache
         return $this->fetchCached($this->key('series', $slug), $fetch);
     }
 
-    /** Drop the cached list for an instance after a mutating action. */
+    /** Drop the cached list for an instance after a mutating action. Hard delete: the next read blocks. */
     public function invalidate(string $type, string $slug): void
     {
         $kind = $type === 'sonarr' ? 'series' : 'movies';
-        $this->cache->delete($this->key($kind, $slug));
+        $this->swr->delete($this->key($kind, $slug));
     }
 
     /**
@@ -56,11 +64,15 @@ class MediaLibraryCache
      */
     private function fetchCached(string $key, callable $fetch): array
     {
-        return $this->cache->get($key, function (ItemInterface $item) use ($fetch) {
-            $result = $fetch();
-            $item->expiresAfter($result === [] ? 0 : self::TTL);
-            return $result;
-        });
+        $hit = $this->swr->getOrCompute($key, self::TTL, self::HARD_TTL, $fetch);
+        if ($hit['state'] === 'stale') {
+            $this->swr->requestRefresh($key);
+        }
+
+        /** @var array<mixed> $value */
+        $value = $hit['value'];
+
+        return $value;
     }
 
     private function key(string $kind, string $slug): string

--- a/symfony/src/Service/Media/MediaLibraryCache.php
+++ b/symfony/src/Service/Media/MediaLibraryCache.php
@@ -3,6 +3,8 @@
 namespace App\Service\Media;
 
 use App\Service\Cache\StaleWhileRevalidateCache;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * Short-TTL cache for the heavy Radarr/Sonarr library list.
@@ -31,7 +33,20 @@ class MediaLibraryCache
     /** Ceiling: past this a read blocks and refetches inline. Bounded staleness, never permanent. */
     public const HARD_TTL = 600; // seconds
 
-    public function __construct(private readonly StaleWhileRevalidateCache $swr) {}
+    /** Cross-request throttle for the "refresh overdue" log line. */
+    private const OVERDUE_LOG_KEY = 'media_library.overdue_logged';
+
+    /** Seconds. How long a requested refresh may go unanswered before it's worth an operator's attention. */
+    private const OVERDUE_THRESHOLD = 180;
+
+    private readonly LoggerInterface $logger;
+
+    public function __construct(
+        private readonly StaleWhileRevalidateCache $swr,
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
 
     /**
      * @param callable():array $fetch
@@ -67,12 +82,47 @@ class MediaLibraryCache
         $hit = $this->swr->getOrCompute($key, self::TTL, self::HARD_TTL, $fetch);
         if ($hit['state'] === 'stale') {
             $this->swr->requestRefresh($key);
+            $this->logOverdueOnce($key);
         }
 
         /** @var array<mixed> $value */
         $value = $hit['value'];
 
         return $value;
+    }
+
+    /**
+     * Hard-miss/stale rebuild never answered within OVERDUE_THRESHOLD seconds
+     * — rate-limited across requests, not just this one, via a short-lived
+     * pool marker. Wrapped
+     * in one try/catch: this sits on the same request path as the library
+     * pages themselves, so a broken pool adapter here must degrade to "skip
+     * the log line", never a 500.
+     */
+    private function logOverdueOnce(string $key): void
+    {
+        try {
+            if (!$this->swr->refreshIsOverdue($key, self::OVERDUE_THRESHOLD)) {
+                return;
+            }
+
+            $pool   = $this->swr->getPool();
+            $marker = $pool->getItem(self::OVERDUE_LOG_KEY);
+            if ($marker->isHit()) {
+                return;
+            }
+            $marker->set(true);
+            $marker->expiresAfter(self::OVERDUE_THRESHOLD);
+            $pool->save($marker);
+
+            $this->logger->error(sprintf(
+                'Library cache refresh overdue for %s (requested >%d s ago) — is the messenger-worker service running?',
+                $key,
+                self::OVERDUE_THRESHOLD,
+            ));
+        } catch (\Throwable) {
+            // Best-effort operational logging only; never let it affect the response.
+        }
     }
 
     private function key(string $kind, string $slug): string

--- a/symfony/tests/Controller/DashboardControllerTest.php
+++ b/symfony/tests/Controller/DashboardControllerTest.php
@@ -56,6 +56,85 @@ class DashboardControllerTest extends TestCase
         $c->setContainer($container);
     }
 
+    /**
+     * Construction helper: threads radarr/sonarr, libraryCache and the
+     * enabled-instance provider through named parameters; every other
+     * argument falls back to whatever the
+     * neighbouring positional constructions above already pass. Defaults
+     * $instances to one enabled Radarr instance (radarr-1) so a test that
+     * only cares about the shared library cache doesn't have to restate the
+     * fan-out wiring every time.
+     */
+    private function makeController(
+        ?HealthService $health = null,
+        ?RadarrClient $radarr = null,
+        ?SonarrClient $sonarr = null,
+        ?JellyseerrClient $jellyseerr = null,
+        ?TmdbClient $tmdb = null,
+        ?WatchlistItemRepository $watchlistRepo = null,
+        ?ServiceInstanceProvider $instances = null,
+        ?\Psr\Log\LoggerInterface $logger = null,
+        ?TranslatorInterface $translator = null,
+        ?CacheInterface $cache = null,
+        ?TautulliClient $tautulli = null,
+        ?\App\Service\DashboardLayoutService $layout = null,
+        ?\App\Service\Media\MediaLibraryCache $libraryCache = null,
+    ): DashboardController {
+        if ($instances === null) {
+            $instances = $this->createMock(ServiceInstanceProvider::class);
+            $instances->method('getEnabled')->willReturnCallback(
+                fn(string $type): array => $type === ServiceInstance::TYPE_RADARR
+                    ? [$this->instance('radarr-1', 'Radarr')] : []
+            );
+        }
+
+        $controller = new DashboardController(
+            $health ?? $this->createMock(HealthService::class),
+            $radarr ?? $this->createMock(RadarrClient::class),
+            $sonarr ?? $this->createMock(SonarrClient::class),
+            $jellyseerr ?? $this->createMock(JellyseerrClient::class),
+            $tmdb ?? $this->createMock(TmdbClient::class),
+            $watchlistRepo ?? $this->createMock(WatchlistItemRepository::class),
+            $instances,
+            $logger ?? new NullLogger(),
+            $translator ?? $this->createMock(TranslatorInterface::class),
+            $cache ?? $this->createMock(CacheInterface::class),
+            $tautulli ?? $this->createMock(TautulliClient::class),
+            $layout ?? new \App\Service\DashboardLayoutService($this->createMock(\App\Service\ConfigService::class)),
+            libraryCache: $libraryCache,
+        );
+        $this->attachRouter($controller);
+
+        return $controller;
+    }
+
+    public function testDashboardMoviesComeFromTheSharedLibraryCacheAndStayInstanceTagged(): void
+    {
+        $pool = new \Symfony\Component\Cache\Adapter\ArrayAdapter();
+        $bus  = new class implements \Symfony\Component\Messenger\MessageBusInterface {
+            public function dispatch(object $message, array $stamps = []): \Symfony\Component\Messenger\Envelope
+            {
+                return new \Symfony\Component\Messenger\Envelope($message);
+            }
+        };
+        $swr     = new \App\Service\Cache\StaleWhileRevalidateCache($pool, $pool, $bus, new \Psr\Log\NullLogger());
+        $library = new \App\Service\Media\MediaLibraryCache($swr);
+
+        // Pre-warm the SHARED per-slug entry the Films page also reads.
+        $swr->write('media.movies.radarr-1', [['id' => 42, 'title' => 'X', 'fanart' => 'f']], \App\Service\Media\MediaLibraryCache::HARD_TTL);
+
+        $radarr = $this->createMock(\App\Service\Media\RadarrClient::class);
+        $radarr->expects($this->never())->method('getMovies'); // warm shared entry ⇒ no upstream call
+
+        $controller = $this->makeController(radarr: $radarr, libraryCache: $library);
+
+        $rows = (new \ReflectionMethod($controller, 'movies'))->invoke($controller);
+
+        $this->assertCount(1, $rows);
+        $this->assertSame(42, $rows[0]['id']);
+        $this->assertSame('radarr-1', $rows[0]['_instanceSlug'], 'dashboard rows must stay instance-tagged');
+    }
+
     public function testQuickLookLibraryBuildsMovieViewModel(): void
     {
         $movieRow = [

--- a/symfony/tests/MessageHandler/RefreshCacheKeyHandlerTest.php
+++ b/symfony/tests/MessageHandler/RefreshCacheKeyHandlerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Tests\MessageHandler;
+
+use App\Message\RefreshCacheKey;
+use App\MessageHandler\RefreshCacheKeyHandler;
+use App\Service\Cache\CacheRefresherInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+class RefreshCacheKeyHandlerTest extends TestCase
+{
+    private function refresher(string $prefix, ?string &$seen): CacheRefresherInterface
+    {
+        return new class($prefix, $seen) implements CacheRefresherInterface {
+            public function __construct(private string $prefix, private ?string &$seen) {}
+            public function supports(string $key): bool { return str_starts_with($key, $this->prefix); }
+            public function refresh(string $key): void { $this->seen = $key; }
+        };
+    }
+
+    /** @param list<array{level: mixed, message: string, context: array<string, mixed>}> $records */
+    private function recordingLogger(array &$records): LoggerInterface
+    {
+        return new class($records) extends AbstractLogger {
+            /** @param list<array{level: mixed, message: string, context: array<string, mixed>}> $records */
+            public function __construct(private array &$records) {}
+
+            public function log($level, string|\Stringable $message, array $context = []): void
+            {
+                $this->records[] = ['level' => $level, 'message' => (string) $message, 'context' => $context];
+            }
+        };
+    }
+
+    public function testRoutesTheKeyToTheOwningRefresher(): void
+    {
+        $a = null; $b = null;
+        $handler = new RefreshCacheKeyHandler([$this->refresher('media.', $a), $this->refresher('queue.', $b)], new NullLogger());
+
+        $handler(new RefreshCacheKey('queue.counts.qbittorrent'));
+
+        $this->assertNull($a);
+        $this->assertSame('queue.counts.qbittorrent', $b);
+    }
+
+    public function testMultipleMatchingRefreshersAreAllCalledAndLogAWarning(): void
+    {
+        $a = null; $b = null;
+        $records = [];
+        $handler = new RefreshCacheKeyHandler(
+            [$this->refresher('media.', $a), $this->refresher('media.movies.', $b)],
+            $this->recordingLogger($records),
+        );
+
+        $handler(new RefreshCacheKey('media.movies.radarr-1'));
+
+        // supports() domains are supposed to be mutually exclusive; an
+        // overlap must not silently pick a "winner" by iteration order —
+        // BOTH refreshers run (they are required to be idempotent) and the
+        // collision is logged so it gets fixed.
+        $this->assertSame('media.movies.radarr-1', $a);
+        $this->assertSame('media.movies.radarr-1', $b);
+        $this->assertCount(1, $records);
+        $this->assertSame('warning', $records[0]['level']);
+        $this->assertSame('media.movies.radarr-1', $records[0]['context']['key']);
+        $this->assertSame(2, $records[0]['context']['count']);
+    }
+
+    public function testUnknownKeyIsAckedNotThrown(): void
+    {
+        $a = null;
+        $records = [];
+        $handler = new RefreshCacheKeyHandler([$this->refresher('media.', $a)], $this->recordingLogger($records));
+
+        $handler(new RefreshCacheKey('nope.whatever')); // must not throw
+
+        $this->assertNull($a);
+        $this->assertCount(1, $records);
+        $this->assertSame('warning', $records[0]['level']);
+        $this->assertSame('nope.whatever', $records[0]['context']['key']);
+    }
+}

--- a/symfony/tests/Service/Cache/MediaLibraryRefresherTest.php
+++ b/symfony/tests/Service/Cache/MediaLibraryRefresherTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Tests\Service\Cache;
+
+use App\Entity\ServiceInstance;
+use App\Service\Cache\MediaLibraryRefresher;
+use App\Service\Cache\StaleWhileRevalidateCache;
+use App\Service\Media\MediaLibraryCache;
+use App\Service\Media\RadarrClient;
+use App\Service\Media\ServiceHealthCache;
+use App\Service\Media\SonarrClient;
+use App\Service\ServiceInstanceProvider;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AllowMockObjectsWithoutExpectations]
+class MediaLibraryRefresherTest extends TestCase
+{
+    private function bus(): MessageBusInterface
+    {
+        return new class implements MessageBusInterface {
+            public function dispatch(object $message, array $stamps = []): Envelope { return new Envelope($message); }
+        };
+    }
+
+    private function swr(ArrayAdapter $pool): StaleWhileRevalidateCache
+    {
+        return new StaleWhileRevalidateCache($pool, $pool, $this->bus(), new NullLogger());
+    }
+
+    private function instances(): ServiceInstanceProvider
+    {
+        $inst = new ServiceInstance(ServiceInstance::TYPE_RADARR, 'radarr-1', 'Radarr', 'http://x', 'k');
+        $p = $this->createMock(ServiceInstanceProvider::class);
+        $p->method('getBySlug')->willReturnCallback(
+            static fn (string $type, string $slug) => ($type === ServiceInstance::TYPE_RADARR && $slug === 'radarr-1') ? $inst : null,
+        );
+
+        return $p;
+    }
+
+    public function testSupportsOnlyLibraryKeys(): void
+    {
+        $r = $this->refresher(new ArrayAdapter(), $this->createMock(RadarrClient::class));
+
+        $this->assertTrue($r->supports('media.movies.radarr-1'));
+        $this->assertTrue($r->supports('media.series.sonarr-1'));
+        $this->assertFalse($r->supports('queue.counts.qbittorrent'));
+    }
+
+    public function testRefreshWritesTheFetchedList(): void
+    {
+        $pool   = new ArrayAdapter();
+        $radarr = $this->createMock(RadarrClient::class);
+        $radarr->method('withInstance')->willReturnSelf();
+        $radarr->expects($this->once())->method('getMovies')->willReturn([['id' => 5]]);
+
+        $this->refresher($pool, $radarr)->refresh('media.movies.radarr-1');
+
+        $this->assertSame(
+            ['value' => [['id' => 5]], 'state' => 'fresh'],
+            $this->swr($pool)->read('media.movies.radarr-1', MediaLibraryCache::TTL),
+        );
+    }
+
+    public function testRefreshIsSkippedWhenTheEntryIsAlreadyFresh(): void
+    {
+        $pool = new ArrayAdapter();
+        $this->swr($pool)->write('media.movies.radarr-1', [['id' => 1]], MediaLibraryCache::HARD_TTL);
+
+        $radarr = $this->createMock(RadarrClient::class);
+        $radarr->expects($this->never())->method('getMovies');
+
+        $this->refresher($pool, $radarr)->refresh('media.movies.radarr-1');
+    }
+
+    public function testRefreshIsSkippedWhenTheCircuitBreakerIsOpen(): void
+    {
+        $pool = new ArrayAdapter();
+        (new ServiceHealthCache($pool))->markDown('radarr', 'radarr-1');
+
+        $radarr = $this->createMock(RadarrClient::class);
+        $radarr->expects($this->never())->method('getMovies');
+
+        $this->refresher($pool, $radarr)->refresh('media.movies.radarr-1');
+    }
+
+    public function testAnEmptyFetchNeverOverwritesAGoodValue(): void
+    {
+        $pool = new ArrayAdapter();
+        $this->swr($pool)->write('media.movies.radarr-1', [['id' => 1]], MediaLibraryCache::HARD_TTL, time() - 120);
+
+        $radarr = $this->createMock(RadarrClient::class);
+        $radarr->method('withInstance')->willReturnSelf();
+        $radarr->method('getMovies')->willReturn([]);
+
+        $this->refresher($pool, $radarr)->refresh('media.movies.radarr-1');
+
+        $hit = $this->swr($pool)->read('media.movies.radarr-1', MediaLibraryCache::TTL);
+        $this->assertSame([['id' => 1]], $hit['value'], 'a failed/empty fetch must leave the previous good value alone');
+    }
+
+    public function testAnUnknownSlugIsANoOp(): void
+    {
+        $radarr = $this->createMock(RadarrClient::class);
+        $radarr->expects($this->never())->method('getMovies');
+
+        $this->refresher(new ArrayAdapter(), $radarr)->refresh('media.movies.does-not-exist');
+    }
+
+    private function refresher(ArrayAdapter $pool, RadarrClient $radarr): MediaLibraryRefresher
+    {
+        return new MediaLibraryRefresher(
+            $this->instances(),
+            $radarr,
+            $this->createMock(SonarrClient::class),
+            $this->swr($pool),
+            new ServiceHealthCache($pool),
+            new NullLogger(),
+        );
+    }
+}

--- a/symfony/tests/Service/Cache/MediaLibraryRefresherTest.php
+++ b/symfony/tests/Service/Cache/MediaLibraryRefresherTest.php
@@ -43,6 +43,19 @@ class MediaLibraryRefresherTest extends TestCase
         return $p;
     }
 
+    /** A provider whose only radarr instance exists but is DISABLED. */
+    private function instancesWithDisabledInstance(): ServiceInstanceProvider
+    {
+        $inst = new ServiceInstance(ServiceInstance::TYPE_RADARR, 'radarr-1', 'Radarr', 'http://x', 'k');
+        $inst->setEnabled(false);
+        $p = $this->createMock(ServiceInstanceProvider::class);
+        $p->method('getBySlug')->willReturnCallback(
+            static fn (string $type, string $slug) => ($type === ServiceInstance::TYPE_RADARR && $slug === 'radarr-1') ? $inst : null,
+        );
+
+        return $p;
+    }
+
     public function testSupportsOnlyLibraryKeys(): void
     {
         $r = $this->refresher(new ArrayAdapter(), $this->createMock(RadarrClient::class));
@@ -110,6 +123,54 @@ class MediaLibraryRefresherTest extends TestCase
         $radarr->expects($this->never())->method('getMovies');
 
         $this->refresher(new ArrayAdapter(), $radarr)->refresh('media.movies.does-not-exist');
+    }
+
+    /**
+     * refresh() also no-ops when the slug resolves to a real instance
+     * that has been disabled since the refresh was queued
+     * (the instance branch, not the "unknown slug" branch tested above).
+     */
+    public function testADisabledInstanceIsANoOp(): void
+    {
+        $radarr = $this->createMock(RadarrClient::class);
+        $radarr->expects($this->never())->method('getMovies');
+
+        $refresher = new MediaLibraryRefresher(
+            $this->instancesWithDisabledInstance(),
+            $radarr,
+            $this->createMock(SonarrClient::class),
+            $this->swr(new ArrayAdapter()),
+            new ServiceHealthCache(new ArrayAdapter()),
+            new NullLogger(),
+        );
+
+        $refresher->refresh('media.movies.radarr-1');
+    }
+
+    /**
+     * An empty slug (a key that is exactly the prefix, e.g. a malformed
+     * "media.movies.") must hit the `$slug === ''`
+     * guard and return before ever consulting the instance provider or
+     * fetching anything.
+     */
+    public function testAnEmptySlugIsANoOp(): void
+    {
+        $radarr = $this->createMock(RadarrClient::class);
+        $radarr->expects($this->never())->method('getMovies');
+
+        $instances = $this->createMock(ServiceInstanceProvider::class);
+        $instances->expects($this->never())->method('getBySlug');
+
+        $refresher = new MediaLibraryRefresher(
+            $instances,
+            $radarr,
+            $this->createMock(SonarrClient::class),
+            $this->swr(new ArrayAdapter()),
+            new ServiceHealthCache(new ArrayAdapter()),
+            new NullLogger(),
+        );
+
+        $refresher->refresh('media.movies.');
     }
 
     private function refresher(ArrayAdapter $pool, RadarrClient $radarr): MediaLibraryRefresher

--- a/symfony/tests/Service/Cache/MessengerTestTransportTest.php
+++ b/symfony/tests/Service/Cache/MessengerTestTransportTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Tests\Service\Cache;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+
+/**
+ * The test env must never talk to the doctrine messenger transport: the
+ * messenger_messages table is not part of the ORM schema SchemaTool builds,
+ * so a real dispatch would fire auto_setup DDL inside every WebTestCase.
+ */
+class MessengerTestTransportTest extends KernelTestCase
+{
+    public function testAsyncTransportIsInMemoryUnderTest(): void
+    {
+        self::bootKernel();
+
+        $transport = self::getContainer()->get('messenger.transport.async');
+
+        $this->assertInstanceOf(InMemoryTransport::class, $transport);
+    }
+}

--- a/symfony/tests/Service/Cache/StaleWhileRevalidateCacheTest.php
+++ b/symfony/tests/Service/Cache/StaleWhileRevalidateCacheTest.php
@@ -1,0 +1,336 @@
+<?php
+
+namespace App\Tests\Service\Cache;
+
+use App\Message\RefreshCacheKey;
+use App\Service\Cache\StaleWhileRevalidateCache;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+
+class StaleWhileRevalidateCacheTest extends TestCase
+{
+    /** @var list<object> */
+    private array $dispatched = [];
+
+    private function bus(bool $throw = false): MessageBusInterface
+    {
+        return new class($this->dispatched, $throw) implements MessageBusInterface {
+            /** @param list<object> $sink */
+            public function __construct(private array &$sink, private bool $throw) {}
+            public function dispatch(object $message, array $stamps = []): Envelope
+            {
+                if ($this->throw) {
+                    throw new \RuntimeException('transport down');
+                }
+                $this->sink[] = $message;
+                return new Envelope($message);
+            }
+        };
+    }
+
+    private function swr(ArrayAdapter $pool, bool $throwingBus = false): StaleWhileRevalidateCache
+    {
+        return new StaleWhileRevalidateCache($pool, $pool, $this->bus($throwingBus), new NullLogger());
+    }
+
+    /** @param list<array{level: mixed, message: string, context: array<string, mixed>}> $records */
+    private function recordingLogger(array &$records): LoggerInterface
+    {
+        return new class($records) extends AbstractLogger {
+            /** @param list<array{level: mixed, message: string, context: array<string, mixed>}> $records */
+            public function __construct(private array &$records) {}
+
+            public function log($level, string|\Stringable $message, array $context = []): void
+            {
+                $this->records[] = ['level' => $level, 'message' => (string) $message, 'context' => $context];
+            }
+        };
+    }
+
+    /** A CacheInterface that always hands back a malformed (non-envelope) result, regardless of $callback. */
+    private function malformedCache(): CacheInterface
+    {
+        return new class implements CacheInterface {
+            public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
+            {
+                return ['not' => 'the expected shape'];
+            }
+            public function delete(string $key): bool { return true; }
+        };
+    }
+
+    public function testReadReturnsNullOnHardMiss(): void
+    {
+        $this->assertNull($this->swr(new ArrayAdapter())->read('k', 60));
+    }
+
+    public function testWriteThenReadIsFresh(): void
+    {
+        $pool = new ArrayAdapter();
+        $swr  = $this->swr($pool);
+        $swr->write('k', ['a' => 1], 600);
+
+        $this->assertSame(['value' => ['a' => 1], 'state' => 'fresh'], $swr->read('k', 60));
+    }
+
+    public function testEntryOlderThanSoftTtlReadsStale(): void
+    {
+        $pool = new ArrayAdapter();
+        $swr  = $this->swr($pool);
+        $swr->write('k', ['a' => 1], 600, time() - 120);
+
+        $hit = $swr->read('k', 60);
+        $this->assertNotNull($hit);
+        $this->assertSame('stale', $hit['state']);
+        $this->assertSame(['a' => 1], $hit['value']);
+    }
+
+    public function testReadTreatsACorruptEnvelopeAsAMissAndDropsIt(): void
+    {
+        $pool = new ArrayAdapter();
+        $item = $pool->getItem('k');
+        $item->set(['unexpected' => 'shape']); // no fetchedAt/value keys
+        $item->expiresAfter(600);
+        $pool->save($item);
+
+        $swr = $this->swr($pool);
+
+        $this->assertNull($swr->read('k', 60));
+        $this->assertFalse($pool->getItem('k')->isHit(), 'a corrupt entry must be dropped, not just skipped');
+    }
+
+    public function testGetOrComputeFetchesOnceThenServesFromCache(): void
+    {
+        $pool  = new ArrayAdapter();
+        $swr   = $this->swr($pool);
+        $calls = 0;
+        $fetch = function () use (&$calls) { $calls++; return ['row']; };
+
+        $first  = $swr->getOrCompute('k', 60, 600, $fetch);
+        $second = $swr->getOrCompute('k', 60, 600, $fetch);
+
+        $this->assertSame(['row'], $first['value']);
+        $this->assertSame('fresh', $first['state']);
+        $this->assertSame(['row'], $second['value']);
+        $this->assertSame(1, $calls, 'second call must hit the cache, not re-fetch');
+    }
+
+    public function testGetOrComputeDoesNotStoreAnEmptyResult(): void
+    {
+        $pool  = new ArrayAdapter();
+        $swr   = $this->swr($pool);
+        $calls = 0;
+        $fetch = function () use (&$calls) { $calls++; return []; };
+
+        $swr->getOrCompute('k', 60, 600, $fetch);
+        $swr->getOrCompute('k', 60, 600, $fetch);
+
+        $this->assertSame(2, $calls, 'an empty result must expire immediately so the next load retries');
+    }
+
+    public function testGetOrComputeTreatsACorruptEnvelopeAsAMissAndRecomputes(): void
+    {
+        $pool = new ArrayAdapter();
+        $item = $pool->getItem('k');
+        $item->set(['unexpected' => 'shape']);
+        $item->expiresAfter(600);
+        $pool->save($item);
+
+        $swr   = $this->swr($pool);
+        $calls = 0;
+        $fetch = function () use (&$calls) { $calls++; return ['row']; };
+
+        $result = $swr->getOrCompute('k', 60, 600, $fetch);
+
+        $this->assertSame(['row'], $result['value']);
+        $this->assertSame('fresh', $result['state']);
+        $this->assertSame(1, $calls);
+    }
+
+    public function testGetOrComputeDoesNotTrustAMalformedContractsCacheResult(): void
+    {
+        // Empty pool: read() reports a genuine hard miss, so getOrCompute()
+        // proceeds to the (here, deliberately broken) contracts cache.
+        $pool  = new ArrayAdapter();
+        $swr   = new StaleWhileRevalidateCache($this->malformedCache(), $pool, $this->bus(), new NullLogger());
+        $calls = 0;
+
+        $result = $swr->getOrCompute('k', 60, 600, function () use (&$calls) { $calls++; return ['fallback']; });
+
+        $this->assertSame(['fallback'], $result['value']);
+        $this->assertSame('fresh', $result['state']);
+        $this->assertSame(1, $calls, 'a malformed contracts-cache result must never be trusted — recompute directly instead');
+    }
+
+    public function testGetOrComputePropagatesAThrowingFetchAndLeavesNoEntry(): void
+    {
+        $pool = new ArrayAdapter();
+        $swr  = $this->swr($pool);
+
+        $this->expectException(\RuntimeException::class);
+        try {
+            $swr->getOrCompute('k', 60, 600, function (): array {
+                throw new \RuntimeException('upstream down');
+            });
+        } finally {
+            $this->assertFalse($pool->getItem('k')->isHit(), 'a throwing fetch must not leave a partial/cached entry behind');
+        }
+    }
+
+    public function testGetOrComputeCanReturnStaleWhenSoftTtlIsAlreadyZero(): void
+    {
+        $pool = new ArrayAdapter();
+        $swr  = $this->swr($pool);
+
+        $result = $swr->getOrCompute('k', 0, 600, fn () => ['row']);
+
+        $this->assertSame(['row'], $result['value']);
+        $this->assertSame('stale', $result['state'], 'state must be derived from fetchedAt like read() does, never hardcoded fresh');
+    }
+
+    public function testRequestRefreshDispatchesOnceInsideTheMarkerWindow(): void
+    {
+        $pool = new ArrayAdapter();
+        $swr  = $this->swr($pool);
+
+        $swr->requestRefresh('k');
+        $swr->requestRefresh('k');
+        $swr->requestRefresh('k');
+
+        $this->assertCount(1, $this->dispatched);
+        $this->assertInstanceOf(RefreshCacheKey::class, $this->dispatched[0]);
+        $this->assertSame('k', $this->dispatched[0]->key);
+    }
+
+    public function testDispatchFailureDropsTheMarkerSoTheNextRequestRetries(): void
+    {
+        $pool = new ArrayAdapter();
+        $swr  = $this->swr($pool, throwingBus: true);
+
+        $swr->requestRefresh('k'); // throws internally, must be swallowed
+
+        $this->assertFalse(
+            $pool->getItem('k.refreshing')->isHit(),
+            'a failed dispatch must not leave the coalescing marker behind for 30 s',
+        );
+    }
+
+    public function testDispatchFailureIsLoggedAsAnError(): void
+    {
+        $pool    = new ArrayAdapter();
+        $records = [];
+        $swr     = new StaleWhileRevalidateCache($pool, $pool, $this->bus(throw: true), $this->recordingLogger($records));
+
+        $swr->requestRefresh('k');
+
+        $this->assertCount(1, $records);
+        $this->assertSame('error', $records[0]['level']);
+        $this->assertSame('k', $records[0]['context']['key']);
+        $this->assertSame(\RuntimeException::class, $records[0]['context']['exception']);
+    }
+
+    public function testRequestRefreshSwallowsAThrowingPoolAndLogsAnError(): void
+    {
+        $pool    = new ArrayAdapter();
+        $records = [];
+        $swr     = new StaleWhileRevalidateCache($pool, $pool, $this->bus(), $this->recordingLogger($records));
+
+        // ArrayAdapter (like every PSR-6 adapter) throws on a reserved
+        // character in the key: {}()/\@: — this must never propagate out of
+        // requestRefresh(), which runs on the main request path.
+        $swr->requestRefresh('bad{key}');
+
+        $this->assertCount(1, $records);
+        $this->assertSame('error', $records[0]['level']);
+        $this->assertSame('bad{key}', $records[0]['context']['key']);
+    }
+
+    public function testWriteRejectsANonPositiveHardTtl(): void
+    {
+        $swr = $this->swr(new ArrayAdapter());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $swr->write('k', ['a' => 1], 0);
+    }
+
+    public function testWriteSkipsWhenTheBackDatedFetchedAtHasAlreadyExpired(): void
+    {
+        $pool = new ArrayAdapter();
+        $swr  = $this->swr($pool);
+
+        $swr->write('k', ['a' => 1], 600, time() - 700); // 700 s old vs a 600 s hard TTL
+
+        $this->assertNull($swr->read('k', 60), 'a write whose effective TTL has already elapsed must not create a live entry');
+    }
+
+    public function testWriteWithABackDatedFetchedAtStillWritesWhenHardLifeRemains(): void
+    {
+        $pool = new ArrayAdapter();
+        $swr  = $this->swr($pool);
+
+        $swr->write('k', ['a' => 1], 600, time() - 400); // 200 s of hard life left
+
+        $hit = $swr->read('k', 1_000_000); // huge soft TTL so it reads back regardless of state
+        $this->assertNotNull($hit);
+        $this->assertSame(['a' => 1], $hit['value']);
+    }
+
+    public function testWriteDoesNotClearAnExistingRefreshingMarker(): void
+    {
+        $pool = new ArrayAdapter();
+        $swr  = $this->swr($pool);
+        $swr->requestRefresh('k'); // sets .refreshing + .requested_at
+
+        $swr->write('k', ['a' => 1], 600);
+
+        $this->assertTrue(
+            $pool->getItem('k.refreshing')->isHit(),
+            'write() only clears the request stamp — the coalescing marker is left to expire on its own',
+        );
+    }
+
+    public function testWriteClearsTheOverdueRequestStamp(): void
+    {
+        $pool = new ArrayAdapter();
+        $swr  = $this->swr($pool);
+
+        $swr->requestRefresh('k');
+        $this->assertTrue($pool->getItem('k.requested_at')->isHit());
+
+        $swr->write('k', ['a' => 1], 600);
+        $this->assertFalse($pool->getItem('k.requested_at')->isHit());
+    }
+
+    public function testRefreshIsOverdueWhenTheStampIsOlderThanTheThreshold(): void
+    {
+        $pool = new ArrayAdapter();
+        $swr  = $this->swr($pool);
+
+        $item = $pool->getItem('k.requested_at');
+        $item->set(time() - 300)->expiresAfter(900);
+        $pool->save($item);
+
+        $this->assertTrue($swr->refreshIsOverdue('k', 180));
+        $this->assertFalse($swr->refreshIsOverdue('k', 600));
+    }
+
+    public function testDeleteDropsValueMarkerAndStamp(): void
+    {
+        $pool = new ArrayAdapter();
+        $swr  = $this->swr($pool);
+        $swr->write('k', ['a' => 1], 600);
+        $swr->requestRefresh('k');
+
+        $swr->delete('k');
+
+        $this->assertNull($swr->read('k', 60));
+        $this->assertFalse($pool->getItem('k.refreshing')->isHit());
+        $this->assertFalse($pool->getItem('k.requested_at')->isHit());
+    }
+}

--- a/symfony/tests/Service/Cache/StaleWhileRevalidateCacheTest.php
+++ b/symfony/tests/Service/Cache/StaleWhileRevalidateCacheTest.php
@@ -269,6 +269,29 @@ class StaleWhileRevalidateCacheTest extends TestCase
         $this->assertNull($swr->read('k', 60), 'a write whose effective TTL has already elapsed must not create a live entry');
     }
 
+    /**
+     * A write that bails out because its back-dated
+     * $fetchedAt has already expired must also drop the .requested_at stamp
+     * — the demand that stamp represents is moot (this write's data is
+     * already too old to serve), so leaving the stamp behind would only
+     * trip refreshIsOverdue() for a request nothing will ever answer.
+     */
+    public function testWriteSkipsAlsoClearsTheRequestedAtStampWhenAlreadyExpired(): void
+    {
+        $pool = new ArrayAdapter();
+        $swr  = $this->swr($pool);
+
+        $swr->requestRefresh('k');
+        $this->assertTrue($pool->getItem('k.requested_at')->isHit());
+
+        $swr->write('k', ['a' => 1], 600, time() - 700); // 700 s old vs a 600 s hard TTL
+
+        $this->assertFalse(
+            $pool->getItem('k.requested_at')->isHit(),
+            'an expired back-dated write must clear the now-moot requested-at stamp',
+        );
+    }
+
     public function testWriteWithABackDatedFetchedAtStillWritesWhenHardLifeRemains(): void
     {
         $pool = new ArrayAdapter();

--- a/symfony/tests/Service/Media/MediaLibraryCacheTest.php
+++ b/symfony/tests/Service/Media/MediaLibraryCacheTest.php
@@ -5,6 +5,8 @@ namespace App\Tests\Service\Media;
 use App\Service\Cache\StaleWhileRevalidateCache;
 use App\Service\Media\MediaLibraryCache;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Messenger\Envelope;
@@ -148,5 +150,67 @@ class MediaLibraryCacheTest extends TestCase
 
         $this->assertSame([['id' => 7]], $rows);
         $this->assertSame(1, $calls, 'the page cannot render without the library, so a hard miss blocks');
+    }
+
+    /** @param list<array{level: mixed, message: string, context: array<string, mixed>}> $records */
+    private function recordingLogger(array &$records): LoggerInterface
+    {
+        return new class($records) extends AbstractLogger {
+            /** @param list<array{level: mixed, message: string, context: array<string, mixed>}> $records */
+            public function __construct(private array &$records) {}
+
+            public function log($level, string|\Stringable $message, array $context = []): void
+            {
+                $this->records[] = ['level' => $level, 'message' => (string) $message, 'context' => $context];
+            }
+        };
+    }
+
+    /**
+     * A stale read that has been overdue (requested >180 s ago, never
+     * answered) for longer than the throttle window must log exactly ONE
+     * error line across repeated reads, not one per read — the throttle
+     * marker is cross-request, not per-object.
+     */
+    public function testAStaleOverdueReadLogsExactlyOneErrorAcrossTwoReads(): void
+    {
+        $pool = new ArrayAdapter();
+        $swr  = $this->swr($pool);
+        $swr->write('media.movies.radarr-1', [['id' => 1]], MediaLibraryCache::HARD_TTL, time() - 120);
+
+        // Prime an overdue refresh request: asked for well past the 180 s
+        // threshold and never answered.
+        $swr->requestRefresh('media.movies.radarr-1');
+        $stamp = $pool->getItem('media.movies.radarr-1.requested_at');
+        $stamp->set(time() - 200);
+        $stamp->expiresAfter(900);
+        $pool->save($stamp);
+        // Clear the .refreshing marker set by requestRefresh() above so the
+        // subsequent reads below re-enter the stale branch cleanly.
+        $pool->deleteItem('media.movies.radarr-1.refreshing');
+
+        $records = [];
+        $cache   = new MediaLibraryCache($swr, $this->recordingLogger($records));
+
+        $cache->movies('radarr-1', fn() => [['id' => 2]]);
+        $cache->movies('radarr-1', fn() => [['id' => 2]]);
+
+        $errors = array_filter($records, static fn(array $r) => $r['level'] === 'error');
+        $this->assertCount(1, $errors, 'the overdue log line must be throttled, not logged on every stale read');
+        $this->assertStringContainsString('media.movies.radarr-1', $errors[array_key_first($errors)]['message']);
+    }
+
+    public function testAStaleReadNotYetOverdueLogsNothing(): void
+    {
+        $pool = new ArrayAdapter();
+        $swr  = $this->swr($pool);
+        $swr->write('media.movies.radarr-1', [['id' => 1]], MediaLibraryCache::HARD_TTL, time() - 120);
+
+        $records = [];
+        $cache   = new MediaLibraryCache($swr, $this->recordingLogger($records));
+
+        $cache->movies('radarr-1', fn() => [['id' => 2]]);
+
+        $this->assertSame([], $records, 'a stale-but-not-yet-overdue read must not log anything');
     }
 }

--- a/symfony/tests/Service/Media/MediaLibraryCacheTest.php
+++ b/symfony/tests/Service/Media/MediaLibraryCacheTest.php
@@ -2,9 +2,13 @@
 
 namespace App\Tests\Service\Media;
 
+use App\Service\Cache\StaleWhileRevalidateCache;
 use App\Service\Media\MediaLibraryCache;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * Short-TTL per-instance cache for the heavy Radarr/Sonarr library list.
@@ -13,9 +17,23 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
  */
 class MediaLibraryCacheTest extends TestCase
 {
+    private function swr(ArrayAdapter $pool): StaleWhileRevalidateCache
+    {
+        $bus = new class implements MessageBusInterface {
+            public function dispatch(object $message, array $stamps = []): Envelope { return new Envelope($message); }
+        };
+
+        return new StaleWhileRevalidateCache($pool, $pool, $bus, new NullLogger());
+    }
+
+    private function cache(?ArrayAdapter $pool = null): MediaLibraryCache
+    {
+        return new MediaLibraryCache($this->swr($pool ?? new ArrayAdapter()));
+    }
+
     public function testMoviesFetchesOnceThenServesFromCache(): void
     {
-        $cache = new MediaLibraryCache(new ArrayAdapter());
+        $cache = $this->cache();
         $calls = 0;
         $fetch = function () use (&$calls) { $calls++; return [['id' => 1]]; };
 
@@ -29,7 +47,7 @@ class MediaLibraryCacheTest extends TestCase
 
     public function testEmptyResultIsNotCached(): void
     {
-        $cache = new MediaLibraryCache(new ArrayAdapter());
+        $cache = $this->cache();
         $calls = 0;
         $fetch = function () use (&$calls) { $calls++; return []; };
 
@@ -41,7 +59,7 @@ class MediaLibraryCacheTest extends TestCase
 
     public function testInstancesAreKeyedIndependently(): void
     {
-        $cache = new MediaLibraryCache(new ArrayAdapter());
+        $cache = $this->cache();
 
         $a = $cache->movies('radarr-1', fn() => [['id' => 1]]);
         $b = $cache->movies('radarr-4k', fn() => [['id' => 99]]);
@@ -52,7 +70,7 @@ class MediaLibraryCacheTest extends TestCase
 
     public function testMoviesAndSeriesDoNotCollide(): void
     {
-        $cache = new MediaLibraryCache(new ArrayAdapter());
+        $cache = $this->cache();
 
         $movies = $cache->movies('x-1', fn() => [['id' => 1]]);
         $series = $cache->series('x-1', fn() => [['id' => 2]]);
@@ -63,7 +81,7 @@ class MediaLibraryCacheTest extends TestCase
 
     public function testInvalidateDropsTheCachedList(): void
     {
-        $cache = new MediaLibraryCache(new ArrayAdapter());
+        $cache = $this->cache();
         $calls = 0;
         $fetch = function () use (&$calls) { $calls++; return [['id' => 1]]; };
 
@@ -76,7 +94,7 @@ class MediaLibraryCacheTest extends TestCase
 
     public function testInvalidateSonarrTargetsSeriesKey(): void
     {
-        $cache = new MediaLibraryCache(new ArrayAdapter());
+        $cache = $this->cache();
         $movieCalls = 0;
         $seriesCalls = 0;
 
@@ -90,5 +108,45 @@ class MediaLibraryCacheTest extends TestCase
 
         $this->assertSame(1, $movieCalls, 'invalidating sonarr must not drop the movies cache');
         $this->assertSame(2, $seriesCalls, 'invalidating sonarr must drop the series cache');
+    }
+
+    public function testAnEntryPastTheSoftTtlIsServedStaleWithoutRefetching(): void
+    {
+        $pool = new ArrayAdapter();
+        $swr  = $this->swr($pool);
+        // Pre-seed an entry fetched two minutes ago: stale (soft 45 s), well
+        // inside the hard window (600 s).
+        $swr->write('media.movies.radarr-1', [['id' => 1]], MediaLibraryCache::HARD_TTL, time() - 120);
+
+        $calls = 0;
+        $rows  = (new MediaLibraryCache($swr))->movies('radarr-1', function () use (&$calls) { $calls++; return [['id' => 2]]; });
+
+        $this->assertSame([['id' => 1]], $rows, 'a stale entry must be served as-is');
+        $this->assertSame(0, $calls, 'a stale read must NOT re-fetch inline');
+    }
+
+    public function testAStaleReadRequestsARefresh(): void
+    {
+        $pool = new ArrayAdapter();
+        $swr  = $this->swr($pool);
+        $swr->write('media.movies.radarr-1', [['id' => 1]], MediaLibraryCache::HARD_TTL, time() - 120);
+
+        (new MediaLibraryCache($swr))->movies('radarr-1', fn() => [['id' => 2]]);
+
+        $this->assertTrue(
+            $pool->getItem('media.movies.radarr-1.refreshing')->isHit(),
+            'a stale read must ask for a background refresh',
+        );
+    }
+
+    public function testAHardMissStillBlocksAndFetchesInline(): void
+    {
+        $pool  = new ArrayAdapter();
+        $calls = 0;
+
+        $rows = (new MediaLibraryCache($this->swr($pool)))->movies('radarr-1', function () use (&$calls) { $calls++; return [['id' => 7]]; });
+
+        $this->assertSame([['id' => 7]], $rows);
+        $this->assertSame(1, $calls, 'the page cannot render without the library, so a hard miss blocks');
     }
 }


### PR DESCRIPTION
`MediaLibraryCache`'s 45 s window expires *inside* a request, so whoever arrives first after it lapses pays the whole `getMovies()` / `getSeries()` fetch before anything renders. On a large library that is the difference between a page that feels instant and one that appears frozen. The dashboard made it worse: `dash.movies` / `dash.series` was a second, uncoordinated 45 s copy of the same payload with no invalidation hook, so a change made on the Films page could stay invisible on the dashboard for the rest of the window.

This adds one small stale-while-revalidate primitive over `cache.app` and puts the library on it:

- **45 s is now the soft TTL.** A lapsed entry is served immediately and a `RefreshCacheKey` message is queued to the existing (until now dormant) `async` transport, so the refetch happens in the already-running `messenger-worker` service instead of in a web worker.
- **600 s is the hard ceiling.** Past it a read still blocks and refetches inline — the library pages cannot render without the list, so a hard miss is never served empty. Staleness is bounded, never permanent.
- **The dashboard reads the same per-instance entry**, so the duplicate fetch path disappears and existing library invalidations finally reach the dashboard.

Unchanged guarantees: an empty/failed fetch is never cached, a mutation invalidates hard (next read refetches), and a refresh is skipped while an instance's circuit breaker is open. A rebuild that goes unanswered for 180 s logs one rate-limited error — the visible symptom of a stopped worker.

Measured on a large live library (~3.4k movies): **Films cold 11.5 s → 0.32 s**, **dashboard recent-additions cold 3.8 s → 0.25 s**, warm timings unchanged.

To verify: load Films cold, wait past 45 s, reload — the second load should not stall; the entry rebuilds in the messenger-worker log. The consumer's `--memory-limit` is raised 256M → 512M so a large-library refresh does not recycle it on every run.

Full suite + `lint:twig` / `lint:yaml` / `lint:container` green. Two follow-ups build on this primitive (a pre-normalized search index, and the Bazarr integration requested in #103), so it is worth landing on its own first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
